### PR TITLE
feat: api make audio conference calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,17 @@
         "@sinclair/typebox": "^0.25.24",
         "fastify": "4.23.2",
         "nodemon": "^2.0.20",
-        "ts-node": "^10.9.1"
+        "sdp-transform": "^2.14.1",
+        "ts-node": "^10.9.1",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
         "@commitlint/config-conventional": "^17.4.2",
         "@types/jest": "^29.4.0",
         "@types/node": "^18.11.18",
+        "@types/sdp-transform": "^2.4.9",
+        "@types/uuid": "^9.0.7",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "eslint": "^8.33.0",
@@ -1840,6 +1844,12 @@
       "integrity": "sha512-ehPtgRgaULsFG8x0NeYJvmyH1hmlfsNLujHe9dQEia/7MAJYdzMSi19JtchUHjmBA6XC/75dK55mzZH+RyieSg==",
       "dev": true
     },
+    "node_modules/@types/sdp-transform": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/sdp-transform/-/sdp-transform-2.4.9.tgz",
+      "integrity": "sha512-bVr+/OoZZy7wrHlNcEAAa6PAgKA4BoXPYVN2EijMC5WnGgQ4ZEuixmKnVs2roiAvr7RhIFVH17QD27cojgIZCg==",
+      "dev": true
+    },
     "node_modules/@types/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
@@ -1850,6 +1860,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
       "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -6281,6 +6297,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/sdp-transform": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
+      "integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw==",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -6987,6 +7011,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,17 @@
     "@sinclair/typebox": "^0.25.24",
     "fastify": "4.23.2",
     "nodemon": "^2.0.20",
-    "ts-node": "^10.9.1"
+    "sdp-transform": "^2.14.1",
+    "ts-node": "^10.9.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",
     "@commitlint/config-conventional": "^17.4.2",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",
+    "@types/sdp-transform": "^2.4.9",
+    "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "eslint": "^8.33.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,6 +5,7 @@ import swaggerUI from '@fastify/swagger-ui';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Static, Type } from '@sinclair/typebox';
 import { FastifyPluginCallback } from 'fastify';
+import apiProductions from './api_productions';
 
 const HelloWorld = Type.String({
   description: 'The magical words!'
@@ -64,6 +65,7 @@ export default (opts: ApiOptions) => {
 
   api.register(healthcheck, { title: opts.title });
   // register other API routes here
+  api.register(apiProductions);
 
   return api;
 };

--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -1,16 +1,186 @@
-import { Type } from '@sinclair/typebox';
-import { FastifyPluginCallback, FastifyRequest } from 'fastify';
-import { NewProduction, Production, SdpOffer, SdpAnswer } from './models';
+import { Type, Static } from '@sinclair/typebox';
+import { FastifyPluginCallback } from 'fastify';
+import { NewProduction, Production, Line } from './models';
+import { SmbProtocol, SmbEndpointDescription } from './smb';
+import { Participant } from './participant';
+import { write, parse } from 'sdp-transform';
+
+type NewProduction = Static<typeof NewProduction>;
+type Production = Static<typeof Production>;
+type Line = Static<typeof Line>;
+
+let participants: { [id: string]: SmbEndpointDescription } = {};
+
+async function createProduction(
+  smb: SmbProtocol,
+  smbServerUrl: string,
+  newProduction: NewProduction
+): Promise<Production | undefined> {
+  let production: Production;
+  let newProductionLines = [];
+
+  for (const line of newProduction.lines) {
+    const id = await smb.allocateConference(smbServerUrl);
+    let newProductionLine: Line = { name: line.name, id: id };
+    newProductionLines.push(newProductionLine);
+  }
+  production = {
+    name: newProduction.name,
+    lines: newProductionLines,
+    id: 'MyProductionId'
+  };
+  if (production) {
+    return production;
+  } else {
+    return;
+  }
+}
+
+function generateOffer(endpoint: SmbEndpointDescription, name: string): string {
+  if (!endpoint.audio) {
+    throw new Error('Missing audio when creating offer');
+  }
+
+  let ssrcs: any = [];
+  endpoint.audio.ssrcs.forEach((ssrcsNr) => {
+    ssrcs.push({
+      ssrc: ssrcsNr,
+      cname: `${name}_audioCName`,
+      mslabel: `${name}_audioMSLabel`,
+      label: `${name}_audioLabel`
+    });
+  });
+
+  let endpointMediaStreamInfo = {
+    audio: {
+      ssrcs: ssrcs
+    }
+  };
+
+  const participant = new Participant(name, endpointMediaStreamInfo, endpoint);
+  participants[name] = endpoint;
+
+  let offer = participant.createOffer();
+  //participant.emit("connect");
+  const sdp = write(offer);
+  return sdp;
+}
+
+async function createEndpoint(
+  smb: SmbProtocol,
+  smbServerUrl: string,
+  lineId: string,
+  clientName: string,
+  audio: boolean,
+  data: boolean
+): Promise<SmbEndpointDescription> {
+  const endpoint: SmbEndpointDescription = await smb.allocateEndpoint(
+    smbServerUrl,
+    lineId,
+    clientName,
+    audio,
+    data,
+    6000
+  );
+  return endpoint;
+}
+
+async function handleAnswerRequest(
+  smb: SmbProtocol,
+  smbServerUrl: string,
+  lineId: string,
+  name: string,
+  endpointDescription: SmbEndpointDescription,
+  answer: string
+): Promise<void> {
+  if (!endpointDescription) {
+    throw new Error(
+      'Missing endpointDescription when handling sdp answer from endpoint'
+    );
+  }
+  if (!endpointDescription.audio) {
+    throw new Error(
+      'Missing endpointDescription audio when handling sdp answer from endpoint'
+    );
+  }
+  endpointDescription.audio.ssrcs = [];
+  //endpointDescription.video.streams = [];
+
+  const parsedAnswer = parse(answer);
+  const answerMediaDescription = parsedAnswer.media[0];
+
+  let transport = endpointDescription['bundle-transport'];
+  if (!transport) {
+    throw new Error(
+      'Missing endpointDescription when handling sdp answer from endpoint'
+    );
+  }
+  if (!transport.dtls) {
+    throw new Error('Missing dtls when handling sdp answer from endpoint');
+  }
+  if (!transport.ice) {
+    throw new Error('Missing ice when handling sdp answer from endpoint');
+  }
+
+  const answerFingerprint = parsedAnswer.fingerprint
+    ? parsedAnswer.fingerprint
+    : answerMediaDescription.fingerprint;
+  if (!answerFingerprint) {
+    throw new Error(
+      'Missing answerFingerprint when handling sdp answer from endpoint'
+    );
+  }
+  transport.dtls.type = answerFingerprint.type;
+  transport.dtls.hash = answerFingerprint.hash;
+  transport.dtls.setup = answerMediaDescription.setup || '';
+  transport.ice.ufrag = answerMediaDescription.iceUfrag || '';
+  transport.ice.pwd = answerMediaDescription.icePwd || '';
+  transport.ice.candidates = !answerMediaDescription.candidates
+    ? []
+    : answerMediaDescription.candidates.flatMap((element) => {
+        return {
+          generation: element.generation ? element.generation : 0,
+          component: element.component,
+          protocol: element.transport.toLowerCase(),
+          port: element.port,
+          ip: element.ip,
+          relPort: element.rport,
+          relAddr: element.raddr,
+          foundation: element.foundation.toString(),
+          priority: parseInt(element.priority.toString(), 10),
+          type: element.type,
+          network: element['network-id']
+        };
+      });
+
+  return await smb.configureEndpoint(
+    smbServerUrl,
+    lineId,
+    name,
+    endpointDescription
+  );
+}
+
+async function getProductions(
+  smb: SmbProtocol,
+  smbServerUrl: string
+): Promise<string[]> {
+  const productions: string[] = await smb.getConferences(smbServerUrl);
+  return productions;
+}
 
 const apiProductions: FastifyPluginCallback = (fastify, opts, next) => {
+  const smbServerUrl = 'http://localhost:8080/conferences/';
+  const smb = new SmbProtocol();
+
   fastify.post<{
-    Body: typeof NewProduction;
-    Reply: typeof Production;
+    Body: NewProduction;
+    Reply: Production | string;
   }>(
     '/production',
     {
       schema: {
-        description: 'Create a new Production resource.',
+        // description: 'Create a new Production resource.',
         body: NewProduction,
         response: {
           200: Production
@@ -19,22 +189,31 @@ const apiProductions: FastifyPluginCallback = (fastify, opts, next) => {
     },
     async (request, reply) => {
       try {
-        //prod = new Production(name, [line1, line2, line3])
-        //Production construction will make calls to smb and set up each line.
+        const production: Production | undefined = await createProduction(
+          smb,
+          smbServerUrl,
+          request.body
+        );
+        if (production) {
+          reply.code(200).send(production);
+        } else {
+          reply.code(500).send('Failed to create production');
+        }
       } catch (err) {
-        //error handling
+        reply
+          .code(500)
+          .send('Exception thrown when trying to create production: ' + err);
       }
     }
   );
 
   fastify.get<{
-    Params: { id: string };
     Reply: any;
   }>(
-    '/production',
+    '/productions',
     {
       schema: {
-        description: 'Retrieves all Production resource.',
+        // description: 'Retrieves all Production resources.',
         response: {
           200: Type.Array(Production)
         }
@@ -42,7 +221,11 @@ const apiProductions: FastifyPluginCallback = (fastify, opts, next) => {
     },
     async (request, reply) => {
       try {
-        //request logic
+        const productions = await getProductions(smb, smbServerUrl);
+        if (productions) {
+          console.log(productions);
+          reply.code(200).send(productions);
+        }
       } catch (err) {
         //error handling
       }
@@ -56,7 +239,7 @@ const apiProductions: FastifyPluginCallback = (fastify, opts, next) => {
     '/productions/:id',
     {
       schema: {
-        description: 'Retrieves a Production resource.',
+        // description: 'Retrieves a Production resource.',
         response: {
           200: Production
         }
@@ -78,7 +261,7 @@ const apiProductions: FastifyPluginCallback = (fastify, opts, next) => {
     '/productions/:id',
     {
       schema: {
-        description: 'Delete a Production resource.',
+        // description: 'Delete a Production resource.',
         response: {
           200: Type.Object({
             message: Type.Literal('removed')
@@ -97,27 +280,93 @@ const apiProductions: FastifyPluginCallback = (fastify, opts, next) => {
 
   fastify.post<{
     Params: { id: string; name: string };
-    Body: typeof SdpOffer;
-    Reply: typeof SdpAnswer;
+    Reply: { [key: string]: any } | string;
   }>(
     '/productions/:id/lines/:name',
     {
       schema: {
-        description: 'Join a Production line.',
-        body: SdpOffer,
+        // description: 'Join a Production line.',
         response: {
-          200: SdpAnswer
+          200: Type.Object({
+            sdp: Type.String(),
+            participants: Type.Array(Type.String())
+          })
         }
       }
     },
     async (request, reply) => {
       try {
-        //Generate SDP, and anything other information required to set up a connection.
+        const endpoint = await createEndpoint(
+          smb,
+          smbServerUrl,
+          request.params.id,
+          request.params.name,
+          true,
+          false
+        );
+        if (!endpoint.audio) {
+          throw new Error('Missing audio when creating sdp offer for endpoint');
+        }
+        if (!endpoint.audio.ssrcs) {
+          throw new Error('Missing ssrcs when creating sdp offer for endpoint');
+        }
+        if (request.params.name in participants) {
+          throw new Error(`Participant ${request.params.name} already exists`);
+        }
+        let sdpOffer = generateOffer(endpoint, request.params.name); //should respond with current participants
+
+        if (sdpOffer) {
+          console.log(sdpOffer);
+          reply
+            .code(200)
+            .send({ sdp: sdpOffer, participants: ['name1', 'name2'] });
+        } else {
+          reply.code(500).send('Failed to generate sdp offer for endpoint');
+        }
       } catch (err) {
-        //error handling
+        reply
+          .code(500)
+          .send('Exception thrown when trying to create production: ' + err);
+      }
+    }
+  );
+
+  fastify.patch<{
+    Params: { id: string; name: string };
+    Body: string;
+    Reply: any;
+  }>(
+    '/productions/:id/lines/:name',
+    {
+      schema: {
+        //description: 'Join a Production line.',
+        response: {
+          200: Type.Object({})
+        }
+      }
+    },
+    async (request, reply) => {
+      try {
+        const participantEndpointDescription =
+          participants[request.params.name];
+        await handleAnswerRequest(
+          smb,
+          smbServerUrl,
+          request.params.id,
+          request.params.name,
+          participantEndpointDescription,
+          request.body
+        );
+        reply.code(200).send({});
+      } catch (err) {
+        reply
+          .code(500)
+          .send('Exception thrown when trying to configure endpoint: ' + err);
       }
     }
   );
 
   next();
 };
+
+export default apiProductions;

--- a/src/mediaStreamsInfo.ts
+++ b/src/mediaStreamsInfo.ts
@@ -1,0 +1,62 @@
+export interface MediaStreamsInfoSsrc {
+  ssrc: string;
+  cname?: string;
+  mslabel?: string;
+  label?: string;
+}
+
+export interface MediaStreamsInfoSsrcGroup {
+  semantics: string;
+  ssrcs: string[];
+}
+
+export interface MediaStreamsInfo {
+  audio: {
+    ssrcs: MediaStreamsInfoSsrc[];
+  };
+  video: {
+    ssrcs: MediaStreamsInfoSsrc[];
+    ssrcGroups: MediaStreamsInfoSsrcGroup[];
+  };
+}
+
+const MediaStreamsInfoSsrcSchema = {
+  ssrc: { type: 'string' },
+  cname: { type: 'string' },
+  mslabel: { type: 'string' },
+  label: { type: 'string' }
+};
+
+const MediaStreamsInfoSsrcGroupSchema = {
+  semantics: { type: 'string' },
+  ssrcs: { type: 'array', items: { type: 'string' } }
+};
+
+export const MediaStreamsSchema = {
+  $id: 'mediastream',
+  type: 'object',
+  properties: {
+    audio: {
+      type: 'object',
+      properties: {
+        ssrcs: {
+          type: 'array',
+          items: { type: 'object', properties: MediaStreamsInfoSsrcSchema }
+        }
+      }
+    },
+    video: {
+      type: 'object',
+      properties: {
+        ssrcs: {
+          type: 'array',
+          items: { type: 'object', properties: MediaStreamsInfoSsrcSchema }
+        },
+        ssrcsGroups: {
+          type: 'array',
+          items: { type: 'object', properties: MediaStreamsInfoSsrcGroupSchema }
+        }
+      }
+    }
+  }
+};

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,19 +1,22 @@
 import { Type } from '@sinclair/typebox';
 
-//Webrtc
-export const SdpOffer = Type.String();
-export const SdpAnswer = Type.String();
-
-//Allocation Models
-export const NewProduction = Type.Object({
-  name: Type.String(),
-  lines: Type.Array(
-    Type.Object({
-      name: Type.String()
-    })
+export const Audio = Type.Object({
+  'relay-type': Type.Array(
+    Type.Union([
+      Type.Literal('forwarder'),
+      Type.Literal('mixed'),
+      Type.Literal('ssrc-rewrite')
+    ])
   )
 });
+export const Video = Type.Object({
+  'relay-type': Type.Union([
+    Type.Literal('forwarder'),
+    Type.Literal('ssrc-rewrite')
+  ])
+});
 
+//Allocation Models
 export const AllocateConference = Type.Object({
   'last-n': Type.Integer(),
   'global-port': Type.Boolean()
@@ -27,34 +30,37 @@ export const AllocateEndpoint = Type.Object({
     dtls: Type.Boolean(),
     sdes: Type.Boolean()
   }),
-  audio: Type.Object({
-    'relay-type': Type.Array(
-      Type.Union([
-        Type.Literal('forwarder'),
-        Type.Literal('mixed'),
-        Type.Literal('ssrc-rewrite')
-      ])
-    )
-  }),
-  video: Type.Object({
-    'relay-type': Type.Union([
-      Type.Literal('forwarder'),
-      Type.Literal('ssrc-rewrite')
-    ])
-  }),
+  audio: Audio,
+  video: Video,
   data: Type.Object({}),
   idleTimeout: Type.Integer()
 });
 
 //Production
-export const Production = Type.Object({
-  id: Type.String(),
+export const NewProduction = Type.Object({
   name: Type.String(),
   lines: Type.Array(
     Type.Object({
       name: Type.String()
     })
   )
+});
+
+export const Production = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  lines: Type.Array(
+    Type.Object({
+      name: Type.String(),
+      id: Type.String()
+    })
+  )
+});
+
+//Line
+export const Line = Type.Object({
+  name: Type.String(),
+  id: Type.String()
 });
 
 //Conference

--- a/src/participant.ts
+++ b/src/participant.ts
@@ -1,0 +1,336 @@
+import { v4 as uuidv4 } from 'uuid';
+import { EventEmitter } from 'events';
+import { SessionDescription } from 'sdp-transform';
+
+import { SfuEndpointDescription } from './sfu/interface';
+import { MediaStreamsInfo } from './mediaStreamsInfo';
+
+export class Participant extends EventEmitter {
+  private resourceId: string;
+  private participantId: string;
+  private nextMid: number = 0;
+  private usedMids: string[] = [];
+
+  protected mediaStreams?: MediaStreamsInfo;
+  protected endpointDescription?: SfuEndpointDescription;
+
+  constructor(
+    resourceId: string,
+    mediaStreams: MediaStreamsInfo | any,
+    endpointDescription: SfuEndpointDescription
+  ) {
+    super();
+    this.resourceId = resourceId;
+    this.participantId = uuidv4();
+    this.mediaStreams = mediaStreams;
+    this.endpointDescription = endpointDescription;
+    this.log(`Create, sfuResourceId ${resourceId}`);
+  }
+
+  getId(): string {
+    return this.participantId;
+  }
+
+  getResourceId(): string {
+    return this.resourceId;
+  }
+
+  protected log(...args: any[]) {
+    console.log(`[participant ${this.participantId}]`, ...args);
+  }
+
+  protected error(...args: any[]) {
+    console.error(`[participant ${this.participantId}]`, ...args);
+  }
+
+  createOffer(): SessionDescription {
+    let offer: SessionDescription = {
+      version: 0,
+      origin: {
+        username: '-',
+        sessionId: '2438602337097565327',
+        sessionVersion: 2,
+        netType: 'IN',
+        ipVer: 4,
+        address: '127.0.0.1'
+      },
+      name: '-',
+      timing: {
+        start: 0,
+        stop: 0
+      },
+      media: []
+    };
+
+    this.addSFUMids(offer);
+    this.addIngestMids(offer);
+
+    let msidSemanticToken = 'feedbackvideomslabel';
+    if (this.mediaStreams) {
+      if (this.mediaStreams.audio.ssrcs.length !== 0) {
+        msidSemanticToken = `${this.mediaStreams.audio.ssrcs[0].mslabel}`;
+      }
+    }
+
+    offer.msidSemantic = {
+      semantic: 'WMS',
+      token: msidSemanticToken
+    };
+    offer.groups = [
+      {
+        type: 'BUNDLE',
+        mids: this.usedMids.join(' ')
+      }
+    ];
+
+    return offer;
+  }
+
+  protected makeMediaDescription(type: string): any {
+    if (!this.endpointDescription) {
+      throw new Error('Missing endpointDescription');
+    }
+    if (!this.endpointDescription['bundle-transport']) {
+      throw new Error('Missing bundle-transport in endpointDescription');
+    }
+
+    const transport = this.endpointDescription['bundle-transport'];
+
+    if (!transport.ice) {
+      throw new Error('Missing ice in endpointDescription');
+    }
+    if (!transport.dtls) {
+      throw new Error('Missing dtls in endpointDescription');
+    }
+    const result = {
+      mid: this.nextMid.toString(),
+      type: type,
+      port: 9,
+      protocol: 'RTP/SAVPF',
+      payloads: '',
+      rtp: [],
+      fmtp: [],
+      rtcpFb: [],
+      rtcp: {
+        port: 9,
+        netType: 'IN',
+        ipVer: 4,
+        address: '0.0.0.0'
+      },
+      ext: [],
+      ssrcs: [],
+      ssrcGroups: [],
+      iceUfrag: transport.ice.ufrag,
+      icePwd: transport.ice.pwd,
+      fingerprint: {
+        type: transport.dtls.type,
+        hash: transport.dtls.hash
+      },
+      setup: transport.dtls.setup === 'actpass' ? 'active' : 'actpass',
+      direction: <
+        'sendrecv' | 'recvonly' | 'sendonly' | 'inactive' | undefined
+      >'sendrecv',
+      rtcpMux: 'rtcp-mux',
+      connection: {
+        version: 4,
+        ip: '0.0.0.0'
+      },
+      candidates: transport.ice.candidates.map((element) => {
+        return {
+          foundation: element.foundation,
+          component: element.component,
+          transport: element.protocol,
+          priority: element.priority,
+          ip: element.ip,
+          port: element.port,
+          type: element.type,
+          raddr: element['rel-addr'],
+          rport: element['rel-port'],
+          generation: element.generation,
+          'network-id': element.network
+        };
+      })
+    };
+
+    this.usedMids.push(this.nextMid.toString());
+    this.nextMid++;
+    return result;
+  }
+
+  protected addIngestMids(offer: SessionDescription) {
+    if (!this.endpointDescription) {
+      throw new Error('Missing endpointDescription');
+    }
+    if (!this.endpointDescription.audio) {
+      throw new Error('Missing endpointDescription audio');
+    }
+    if (!this.mediaStreams) {
+      throw new Error('Missing endpointDescription audio');
+    }
+
+    const audio = this.endpointDescription.audio;
+    const audioPayloadType = audio['payload-type'];
+
+    for (let element of this.mediaStreams.audio.ssrcs) {
+      let audioDescription = this.makeMediaDescription('audio');
+      audioDescription.payloads = audioPayloadType.id.toString();
+      audioDescription.rtp = [
+        {
+          payload: audioPayloadType.id,
+          codec: audioPayloadType.name,
+          rate: audioPayloadType.clockrate,
+          encoding: audioPayloadType.channels
+        }
+      ];
+
+      const parameters = Object.keys(audioPayloadType.parameters);
+      if (parameters.length !== 0) {
+        audioDescription.fmtp = [
+          {
+            payload: audioPayloadType.id,
+            config: parameters
+              .map(
+                (element) =>
+                  `${element}=${audioPayloadType.parameters[element]}`
+              )
+              .join(';')
+          }
+        ];
+      }
+
+      audioDescription.ext = audio['rtp-hdrexts'].flatMap((element) => {
+        return { value: element.id, uri: element.uri };
+      });
+
+      audioDescription.ssrcs.push({
+        id: element.ssrc,
+        attribute: 'cname',
+        value: element.cname
+      });
+      audioDescription.ssrcs.push({
+        id: element.ssrc,
+        attribute: 'label',
+        value: element.label
+      });
+      audioDescription.ssrcs.push({
+        id: element.ssrc,
+        attribute: 'mslabel',
+        value: element.mslabel
+      });
+      audioDescription.ssrcs.push({
+        id: element.ssrc,
+        attribute: 'msid',
+        value: `${element.mslabel} ${element.label}`
+      });
+
+      offer.media.push(audioDescription);
+    }
+
+    // let videoMsLabels = new Set(this.mediaStreams.video.ssrcs.flatMap(element => element.mslabel));
+
+    // for (let msLabel of videoMsLabels) {
+    //   const video = this.endpointDescription.video;
+    //   let videoDescription = this.makeMediaDescription('video');
+    //   videoDescription.payloads = video["payload-types"]
+    //     .flatMap(element => element.id)
+    //     .join(' ');
+    //   videoDescription.rtp = video["payload-types"].flatMap(element => {
+    //     return {
+    //       payload: element.id,
+    //       codec: element.name,
+    //       rate: element.clockrate,
+    //       encoding: element.channels
+    //     }
+    //   });
+    //   videoDescription.ext = video["rtp-hdrexts"].flatMap(element => {
+    //     return { value: element.id, uri: element.uri }
+    //   });
+
+    //   video["payload-types"].forEach(payloadType => {
+    //     const parameters = Object.keys(payloadType.parameters);
+    //     if (parameters.length !== 0) {
+    //       videoDescription.fmtp.push({
+    //         payload: payloadType.id,
+    //         config: parameters
+    //           .map(element => `${element}=${payloadType.parameters[element]}`)
+    //           .join(';')
+    //       });
+    //     }
+
+    //     payloadType["rtcp-fbs"].forEach(rtcpFb => {
+    //       videoDescription.rtcpFb.push({
+    //         payload: payloadType.id,
+    //         type: rtcpFb.type,
+    //         subtype: rtcpFb.subtype
+    //       });
+    //     });
+    //   });
+
+    //   for (let ssrc of this.mediaStreams.video.ssrcs.filter(element => element.mslabel === msLabel)) {
+    //     videoDescription.ssrcs.push({ id: ssrc.ssrc, attribute: 'cname', value: ssrc.cname });
+    //     videoDescription.ssrcs.push({ id: ssrc.ssrc, attribute: 'label', value: ssrc.label });
+    //     videoDescription.ssrcs.push({ id: ssrc.ssrc, attribute: 'mslabel', value: ssrc.mslabel });
+    //     videoDescription.ssrcs.push({ id: ssrc.ssrc, attribute: 'msid', value: `${ssrc.mslabel} ${ssrc.label}` });
+    //   }
+
+    //   videoDescription.ssrcGroups = this.mediaStreams.video.ssrcGroups.flatMap(element => {
+    //     return {
+    //       semantics: element.semantics,
+    //       ssrcs: element.ssrcs.join(' ')
+    //     }
+    //   });
+    //   offer.media.push(videoDescription);
+    // }
+  }
+
+  protected addSFUMids(offer: SessionDescription) {
+    // const video = this.endpointDescription.video;
+    // const videoSsrc = video.streams[0].sources[0].main;
+
+    // let videoDescription = this.makeMediaDescription('video');
+    // videoDescription.payloads = video["payload-types"]
+    //   .flatMap(element => element.id)
+    //   .join(' ');
+    // videoDescription.rtp = video["payload-types"].flatMap(element => {
+    //   return {
+    //     payload: element.id,
+    //     codec: element.name,
+    //     rate: element.clockrate,
+    //     encoding: element.channels
+    //   }
+    // });
+
+    // video["payload-types"].forEach(payloadType => {
+    //   const parameters = Object.keys(payloadType.parameters);
+    //   if (parameters.length !== 0) {
+    //     videoDescription.fmtp.push({
+    //       payload: payloadType.id,
+    //       config: parameters
+    //         .map(element => `${element}=${payloadType.parameters[element]}`)
+    //         .join(';')
+    //     });
+    //   }
+    // });
+
+    // videoDescription.ext = video["rtp-hdrexts"].flatMap(element => {
+    //   return { value: element.id, uri: element.uri }
+    // });
+    // videoDescription.ssrcs = [
+    //   { id: videoSsrc, attribute: 'cname', value: 'feedbackvideocname' },
+    //   { id: videoSsrc, attribute: 'label', value: 'feedbackvideolabel' },
+    //   { id: videoSsrc, attribute: 'mslabel', value: 'feedbackvideomslabel' },
+    //   { id: videoSsrc, attribute: 'msid', value: 'feedbackvideomslabel feedbackvideolabel' }
+    // ];
+    // offer.media.push(videoDescription);
+
+    let dataDescription = this.makeMediaDescription('application');
+    dataDescription.protocol = 'UDP/DTLS/SCTP';
+    dataDescription.payloads = 'webrtc-datachannel';
+    dataDescription.sctpmap = {
+      sctpmapNumber: 5000,
+      app: 'webrtc-datachannel',
+      maxMessageSize: 262144
+    };
+    offer.media.push(dataDescription);
+  }
+}

--- a/src/sfu/interface.ts
+++ b/src/sfu/interface.ts
@@ -1,0 +1,86 @@
+export enum SfuType {
+  smb = 'SMB'
+}
+
+interface SfuCandidate {
+  generation: number;
+  component: number;
+  protocol: string;
+  port: number;
+  ip: string;
+  'rel-port'?: number;
+  'rel-addr'?: string;
+  foundation: string;
+  priority: number;
+  type: string;
+  network?: number;
+}
+
+export interface SfuTransport {
+  'rtcp-mux'?: boolean;
+
+  ice?: {
+    ufrag: string;
+    pwd: string;
+    candidates: SfuCandidate[];
+  };
+  dtls?: {
+    setup: string;
+    type: string;
+    hash: string;
+  };
+}
+
+interface RtcpFeedback {
+  type: string;
+  subtype: string;
+}
+
+interface SfuPayloadType {
+  id: number;
+  name: string;
+  clockrate: number;
+  channels?: number;
+  parameters?: any;
+  'rtcp-fbs'?: RtcpFeedback[];
+}
+
+interface SfuRtpHeaderExtension {
+  id: number;
+  uri: string;
+}
+
+export interface SfuVideoSource {
+  main: number;
+  feedback?: number;
+}
+
+export interface SfuVideoStream {
+  sources: SfuVideoSource[];
+  id: string;
+  content: string;
+}
+
+export interface SfuEndpointDescription {
+  'bundle-transport'?: SfuTransport;
+  audio?: {
+    ssrcs: number[];
+    'payload-type': SfuPayloadType;
+    'rtp-hdrexts': SfuRtpHeaderExtension[];
+  };
+
+  video?: {
+    streams: SfuVideoStream[];
+    'payload-types': SfuPayloadType[];
+    'rtp-hdrexts'?: SfuRtpHeaderExtension[];
+  };
+}
+
+// export interface SfuProtocol {
+//   //log(...args: any[]);
+//   allocateEndpoint(conferenceId: string,
+//     endpointId: string, audio: boolean, video: boolean, data: boolean): Promise<SfuEndpointDescription>;
+//   configureEndpoint(conferenceId: string, endpointId: string,
+//     endpointDescription: SfuEndpointDescription): Promise<void>;
+
+// }

--- a/src/smb.ts
+++ b/src/smb.ts
@@ -1,0 +1,181 @@
+interface SmbCandidate {
+  generation: number;
+  component: number;
+  protocol: string;
+  port: number;
+  ip: string;
+  'rel-port'?: number;
+  'rel-addr'?: string;
+  foundation: string;
+  priority: number;
+  type: string;
+  network?: number;
+}
+
+interface SmbTransport {
+  'rtcp-mux'?: boolean;
+  ice?: {
+    ufrag: string;
+    pwd: string;
+    candidates: SmbCandidate[];
+  };
+  dtls?: {
+    setup: string;
+    type: string;
+    hash: string;
+  };
+}
+
+interface RtcpFeedback {
+  type: string;
+  subtype: string;
+}
+
+interface SmbPayloadType {
+  id: number;
+  name: string;
+  clockrate: number;
+  channels?: number;
+  parameters?: any;
+  'rtcp-fbs'?: RtcpFeedback[];
+}
+
+interface SmbRtpHeaderExtension {
+  id: number;
+  uri: string;
+}
+
+export interface SmbVideoSource {
+  main: number;
+  feedback?: number;
+}
+
+export interface SmbVideoStream {
+  sources: SmbVideoSource[];
+  id: string;
+  content: string;
+}
+
+export interface SmbEndpointDescription {
+  'bundle-transport'?: SmbTransport;
+  audio?: {
+    ssrcs: number[];
+    'payload-type': SmbPayloadType;
+    'rtp-hdrexts': SmbRtpHeaderExtension[];
+  };
+
+  video?: {
+    streams: SmbVideoStream[];
+    'payload-types': SmbPayloadType[];
+    'rtp-hdrexts'?: SmbRtpHeaderExtension[];
+  };
+
+  data?: {
+    port: number;
+  };
+  idleTimeout?: number;
+}
+
+export class SmbProtocol {
+  async allocateConference(smbUrl: string): Promise<string> {
+    const allocateResponse = await fetch(smbUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: '{}'
+    });
+
+    if (!allocateResponse.ok) {
+      throw new Error(
+        'Failed to allocate resource: ' + JSON.stringify(allocateResponse)
+      );
+    }
+
+    const allocateResponseJson: any = await allocateResponse.json();
+    return allocateResponseJson['id'];
+  }
+
+  async allocateEndpoint(
+    smbUrl: string,
+    conferenceId: string,
+    endpointId: string,
+    audio: boolean,
+    data: boolean,
+    idleTimeout: number
+  ): Promise<SmbEndpointDescription> {
+    let request: any = {
+      action: 'allocate',
+      'bundle-transport': {
+        'ice-controlling': true,
+        ice: true,
+        dtls: true,
+        sdes: false
+      }
+    };
+
+    if (audio) {
+      request['audio'] = { 'relay-type': 'mixed' };
+    }
+    if (data) {
+      request['data'] = {};
+    }
+    if (idleTimeout) {
+      request['idleTimeout'] = idleTimeout;
+    }
+    console.log(request);
+
+    const url = smbUrl + conferenceId + '/' + endpointId;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(request)
+    });
+
+    if (!response.ok) {
+      console.log(JSON.stringify(request));
+      throw new Error('Failed to allocate endpoint');
+    }
+
+    const smbEndpointDescription: any = await response.json();
+    return smbEndpointDescription;
+  }
+
+  async configureEndpoint(
+    smbUrl: string,
+    conferenceId: string,
+    endpointId: string,
+    endpointDescription: SmbEndpointDescription
+  ): Promise<void> {
+    let request = JSON.parse(JSON.stringify(endpointDescription));
+    request['action'] = 'configure';
+    const url = smbUrl + conferenceId + '/' + endpointId;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(request)
+    });
+
+    if (!response.ok) {
+      console.log(JSON.stringify(request));
+      throw new Error('Failed to configure endpoint');
+    }
+  }
+
+  async getConferences(smbUrl: string): Promise<string[]> {
+    const response = await fetch(smbUrl, {
+      method: 'GET'
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const responseBody: any = await response.json();
+    return responseBody;
+  }
+}


### PR DESCRIPTION
Added a fastify api to allow communication with smb. This allows intercom-client to make create endpoint calls which returns an sdp offer. This sdp offer is created by the intercom-manager based on information provided by smb. Once an sdp offer is received the intercom client can set up the necessary peerConnections and send its sdp answer to the intercom-manager which configures the smb instance.