### PR TITLE
feat: return line object on patch

### DIFF
--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -420,7 +420,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
       schema: {
         //description: 'Join a Production line.',
         response: {
-          200: Type.Object({})
+          200: Line
         }
       }
     },
@@ -444,7 +444,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
           connectionEndpointDescription,
           request.body
         );
-        reply.code(200);
+        reply.code(200).send(line);
       } catch (err) {
         reply
           .code(500)

--- a/src/models.ts
+++ b/src/models.ts
@@ -44,13 +44,15 @@ export const NewProduction = Type.Object({
   )
 });
 
+export const Connections = Type.Record(Type.String(), Type.Any());
+
 export const Production = Type.Object({
   name: Type.String(),
   lines: Type.Array(
     Type.Object({
       name: Type.String(),
       id: Type.String(),
-      connections: Type.Any()
+      connections: Connections
     })
   )
 });
@@ -58,5 +60,5 @@ export const Production = Type.Object({
 export const Line = Type.Object({
   name: Type.String(),
   id: Type.String(),
-  connections: Type.Any()
+  connections: Connections
 });


### PR DESCRIPTION
Line object is now returned on patch. The line object contains all associated connections(users). It is also possible to retrieve any line object by using the appropriate api request.