### PR TITLE
feat: poll check smb connection then prune ProductionManager connections

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -5,7 +5,9 @@ describe('api', () => {
     const server = api({
       title: 'my awesome service',
       smbServerBaseUrl: 'http://localhost',
-      endpointIdleTimeout: '60'
+      endpointIdleTimeout: '60',
+      smbPoll: false,
+      smbPollInterval_s: '60'
     });
     const response = await server.inject({
       method: 'GET',

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,6 +41,8 @@ export interface ApiOptions {
   title: string;
   smbServerBaseUrl: string;
   endpointIdleTimeout: string;
+  smbPoll: boolean;
+  smbPollInterval_s: string;
 }
 
 export default (opts: ApiOptions) => {
@@ -69,7 +71,9 @@ export default (opts: ApiOptions) => {
   // register other API routes here
   api.register(apiProductions, {
     smbServerBaseUrl: opts.smbServerBaseUrl,
-    endpointIdleTimeout: opts.endpointIdleTimeout
+    endpointIdleTimeout: opts.endpointIdleTimeout,
+    smbPoll: opts.smbPoll,
+    smbPollInterval_s: opts.smbPollInterval_s
   });
 
   return api;

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,10 +9,16 @@ if (!process.env.SMB_ADDRESS) {
 const ENDPOINT_IDLE_TIMEOUT_S: string =
   process.env.ENDPOINT_IDLE_TIMEOUT_S ?? '180';
 
+const SMB_POLL: boolean = process.env.SMB_POLL === 'true';
+
+const SMB_POLL_INTERVAL_S: string = process.env.SMB_POLL_INTERVAL_S ?? '60';
+
 const server = api({
   title: 'intercom-manager',
   smbServerBaseUrl: SMB_ADDRESS,
-  endpointIdleTimeout: ENDPOINT_IDLE_TIMEOUT_S
+  endpointIdleTimeout: ENDPOINT_IDLE_TIMEOUT_S,
+  smbPoll: SMB_POLL,
+  smbPollInterval_s: SMB_POLL_INTERVAL_S
 });
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 8000;

--- a/src/smb.ts
+++ b/src/smb.ts
@@ -91,6 +91,19 @@ interface BaseAllocationRequest {
   idleTimeout?: number;
 }
 
+export interface DetailedConference {
+  dtlsState: string;
+  iceState: string;
+  id: string;
+  isActiveTalker: boolean;
+  isDominantSpeaker: boolean;
+  ActiveTalker?: {
+    noiseLevel: number;
+    ptt: boolean;
+    score: number;
+  };
+}
+
 export class SmbProtocol {
   async allocateConference(smbUrl: string): Promise<string> {
     const allocateResponse = await fetch(smbUrl, {
@@ -200,6 +213,23 @@ export class SmbProtocol {
     }
 
     const responseBody: string[] = await response.json();
+    return responseBody;
+  }
+
+  async getConference(
+    smbUrl: string,
+    conferenceId: string
+  ): Promise<DetailedConference[]> {
+    const url = smbUrl + conferenceId;
+    const response = await fetch(url, {
+      method: 'GET'
+    });
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const responseBody: DetailedConference[] = await response.json();
     return responseBody;
   }
 }


### PR DESCRIPTION
Check smb on interval.

SMB_POLL=true // allows polling functionality to be toggled. Turned off in unit test.
SMB_POLL_INTERVAL_S=20 // sets the interval of the poll. There is a check that stops the interval from ever being lower than 20s.