### PR TITLE
feat: new user always creates new endpoint

### DIFF
--- a/aws/ecs/taskdef-dev.json
+++ b/aws/ecs/taskdef-dev.json
@@ -18,14 +18,6 @@
         {
           "name": "SMB_ADDRESS",
           "value": "http://13.49.224.46:8280"
-        },
-        {
-          "name": "SMB_POLL",
-          "value": "true"
-        },
-        {
-          "name": "SMB_POLL_INTERVAL_S",
-          "value": "60"
         }
       ],
       "environmentFiles": [],

--- a/readme.md
+++ b/readme.md
@@ -19,16 +19,12 @@ Start an Intercom Manager instance:
 docker run -d -p 8000:8000 \
   -e PORT=8000 \
   -e SMB_ADDRESS=http://<smburl>:<smbport> \
-  -e SMB_POLL=true \
-  -e SMB_POLL_INTERVAL_S=60 \
   eyevinntechnology/intercom-manager
 ```
 
 ```
   PORT=8000                             intercom-manager api port.
   SMB_ADDRESS=http://<smburl>:<smbport> The address:port of the Symphony Media Bridge instance.
-  SMB_POLL=true                         Activate regular interval polling to remove unused endpoints. Defaults to false.
-  SMB_POLL_INTERVAL_S=60                Polling interval length in seconds. Defaults to 60. Api will never poll more often than every 20s.
 ```
 
 API docs is then available on `http://localhost:8000/docs/`

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -5,9 +5,7 @@ describe('api', () => {
     const server = api({
       title: 'my awesome service',
       smbServerBaseUrl: 'http://localhost',
-      endpointIdleTimeout: '60',
-      smbPoll: false,
-      smbPollInterval_s: '60'
+      endpointIdleTimeout: '60'
     });
     const response = await server.inject({
       method: 'GET',

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,8 +41,6 @@ export interface ApiOptions {
   title: string;
   smbServerBaseUrl: string;
   endpointIdleTimeout: string;
-  smbPoll: boolean;
-  smbPollInterval_s: string;
 }
 
 export default (opts: ApiOptions) => {
@@ -71,9 +69,7 @@ export default (opts: ApiOptions) => {
   // register other API routes here
   api.register(apiProductions, {
     smbServerBaseUrl: opts.smbServerBaseUrl,
-    endpointIdleTimeout: opts.endpointIdleTimeout,
-    smbPoll: opts.smbPoll,
-    smbPollInterval_s: opts.smbPollInterval_s
+    endpointIdleTimeout: opts.endpointIdleTimeout
   });
 
   return api;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import { EventEmitter } from 'events';
 import { SessionDescription } from 'sdp-transform';
 
@@ -17,15 +16,17 @@ export class Connection extends EventEmitter {
 
   protected mediaStreams?: MediaStreamsInfo;
   protected endpointDescription?: SfuEndpointDescription;
+  protected endpointId?: string;
 
   constructor(
     resourceId: string,
     mediaStreams: MediaStreamsInfo,
-    endpointDescription: SfuEndpointDescription
+    endpointDescription: SfuEndpointDescription,
+    endpointId: string
   ) {
     super();
     this.resourceId = resourceId;
-    this.connectionId = uuidv4();
+    this.connectionId = endpointId;
     this.mediaStreams = mediaStreams;
     this.endpointDescription = endpointDescription;
     this.log(`Create, sfuResourceId ${resourceId}`);

--- a/src/models.ts
+++ b/src/models.ts
@@ -125,7 +125,12 @@ export const SmbEndpointDescription = Type.Object({
   idleTimeout: Type.Optional(Type.Number())
 });
 
-export const Connections = Type.Record(Type.String(), SmbEndpointDescription);
+export const Endpoint = Type.Object({
+  endpointId: Type.String(),
+  sessionDescription: SmbEndpointDescription
+});
+
+export const Connections = Type.Record(Type.String(), Endpoint);
 
 export const Production = Type.Object({
   name: Type.String(),

--- a/src/production_manager.test.ts
+++ b/src/production_manager.test.ts
@@ -284,7 +284,8 @@ describe('production_manager', () => {
       'productionname',
       'linename',
       'username',
-      SmbEndpointDescriptionMock
+      SmbEndpointDescriptionMock,
+      'endpoinId'
     );
     const productionLines =
       productionManagerTest.getProduction('productionname')?.lines;
@@ -294,7 +295,12 @@ describe('production_manager', () => {
     const endpointDescription = productionManagerTest.getLine(
       productionLines,
       'linename'
-    )?.connections['username'];
+    )?.connections['username'].sessionDescription;
+    const endpointId = productionManagerTest.getLine(
+      productionLines,
+      'linename'
+    )?.connections['username'].endpointId;
     expect(endpointDescription).toStrictEqual(SmbEndpointDescriptionMock);
+    expect(endpointId).toStrictEqual('endpoinId');
   });
 });

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -104,7 +104,8 @@ export class ProductionManager {
     productionName: string,
     lineName: string,
     userName: string,
-    endpointDescription: SmbEndpointDescription
+    endpointDescription: SmbEndpointDescription,
+    endpointId: string
   ): void {
     const production = this.getProduction(productionName);
     if (production) {
@@ -112,7 +113,10 @@ export class ProductionManager {
         (line) => line.name === lineName
       );
       if (matchedLine) {
-        matchedLine.connections[userName] = endpointDescription;
+        matchedLine.connections[userName] = {
+          sessionDescription: endpointDescription,
+          endpointId: endpointId
+        };
       }
     } else {
       throw new Error(

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,18 +7,12 @@ if (!process.env.SMB_ADDRESS) {
 }
 
 const ENDPOINT_IDLE_TIMEOUT_S: string =
-  process.env.ENDPOINT_IDLE_TIMEOUT_S ?? '180';
-
-const SMB_POLL: boolean = process.env.SMB_POLL === 'true';
-
-const SMB_POLL_INTERVAL_S: string = process.env.SMB_POLL_INTERVAL_S ?? '60';
+  process.env.ENDPOINT_IDLE_TIMEOUT_S ?? '60';
 
 const server = api({
   title: 'intercom-manager',
   smbServerBaseUrl: SMB_ADDRESS,
-  endpointIdleTimeout: ENDPOINT_IDLE_TIMEOUT_S,
-  smbPoll: SMB_POLL,
-  smbPollInterval_s: SMB_POLL_INTERVAL_S
+  endpointIdleTimeout: ENDPOINT_IDLE_TIMEOUT_S
 });
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 8000;


### PR DESCRIPTION
Previously we enforced a single smb endpoint resource per user connection and were using a polling solution to explicitly remove it when unused or leaving the call. We used the username as an id to identify the corresponding endpoint resource. A problem was that smb's version we are using does not support explicit deletion of endpoint resources even though the documentation seems to imply that it should.

This rework changes the design philosophy of endpoint generation for user connections. We will now instead be creating a new endpoint(assigned a random uuid on creation) every time a user attempts to establish a connection. I have also lowered the  default smb expiry timeout for endpoints to 60s. This changes nothing for the user experience in the application. 

Will need to think about how we to keep the manager clean from unconnected users. [One idea](https://github.com/orgs/Eyevinn/projects/23/views/1?pane=issue&itemId=47675841) is to have the app do a long poll. The manager can then use this to determine if a user should be released in the manager. As soon as there is no longer a poll heart beat we release the user etc..