### PR TITLE
chore: changed models and updated tests

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,7 @@ import { Type, Static } from '@sinclair/typebox';
 
 export type NewProduction = Static<typeof NewProduction>;
 export type Production = Static<typeof Production>;
+export type ProductionResponse = Static<typeof ProductionResponse>;
 export type Line = Static<typeof Line>;
 export type SmbEndpointDescription = Static<typeof SmbEndpointDescription>;
 export type DetailedConference = Static<typeof DetailedConference>;
@@ -134,17 +135,22 @@ export const Connections = Type.Record(Type.String(), Endpoint);
 
 export const Production = Type.Object({
   name: Type.String(),
+  productionid: Type.String(),
   lines: Type.Array(
     Type.Object({
       name: Type.String(),
-      id: Type.String(),
+      smbid: Type.String(),
       connections: Connections
     })
   )
 });
 
+export const ProductionResponse = Type.Object({
+  productionid: Type.String()
+});
+
 export const Line = Type.Object({
   name: Type.String(),
-  id: Type.String(),
+  smbid: Type.String(),
   connections: Connections
 });

--- a/src/production_manager.test.ts
+++ b/src/production_manager.test.ts
@@ -69,11 +69,13 @@ describe('production_manager', () => {
     };
 
     productionManagerTest.createProduction(newProduction);
-    const production = productionManagerTest.getProduction(newProduction.name);
+    const production = productionManagerTest.getProduction('1');
 
+    expect(production).not.toBe(undefined);
     expect(production?.name).toStrictEqual('productionname');
+    expect(production?.productionid).toStrictEqual('1');
     expect(production?.lines[0].name).toStrictEqual('linename');
-    expect(production?.lines[0].id).toStrictEqual('');
+    expect(production?.lines[0].smbid).toStrictEqual('');
     expect(production?.lines[0].connections).toStrictEqual({});
   });
 });
@@ -116,10 +118,11 @@ describe('production_manager', () => {
 
     const production: Production = {
       name: 'productionname',
+      productionid: '1',
       lines: [
         {
           name: 'linename',
-          id: '',
+          smbid: '',
           connections: {}
         }
       ]
@@ -175,10 +178,11 @@ describe('production_manager', () => {
 
     const production1: Production = {
       name: 'productionname1',
+      productionid: '1',
       lines: [
         {
           name: 'linename1',
-          id: '',
+          smbid: '',
           connections: {}
         }
       ]
@@ -186,10 +190,11 @@ describe('production_manager', () => {
 
     const production2: Production = {
       name: 'productionname2',
+      productionid: '2',
       lines: [
         {
           name: 'linename2',
-          id: '',
+          smbid: '',
           connections: {}
         }
       ]
@@ -244,17 +249,17 @@ describe('production_manager', () => {
 
     productionManagerTest.createProduction(newProduction);
     const lineIdBefore =
-      productionManagerTest.getProduction('productionname')?.lines[0].id;
+      productionManagerTest.getProduction('1')?.lines[0].smbid;
     expect(lineIdBefore).toStrictEqual('');
-    productionManagerTest.setLineId('productionname', 'linename', 'newLineId');
+    productionManagerTest.setLineId('1', 'linename', 'newLineId');
     const lineIdAfter =
-      productionManagerTest.getProduction('productionname')?.lines[0].id;
+      productionManagerTest.getProduction('1')?.lines[0].smbid;
     expect(lineIdAfter).toStrictEqual('newLineId');
   });
 });
 
 describe('production_manager', () => {
-  it('set new line id returns undefined if line is not found', async () => {
+  it('set new line smb id returns undefined if line is not found', async () => {
     const productionManagerTest = new ProductionManager();
 
     const noline = productionManagerTest.setLineId(
@@ -281,14 +286,13 @@ describe('production_manager', () => {
 
     productionManagerTest.createProduction(newProduction);
     productionManagerTest.addConnectionToLine(
-      'productionname',
+      '1',
       'linename',
       'username',
       SmbEndpointDescriptionMock,
       'endpoinId'
     );
-    const productionLines =
-      productionManagerTest.getProduction('productionname')?.lines;
+    const productionLines = productionManagerTest.getProduction('1')?.lines;
     if (!productionLines) {
       fail('Test failed due to productionLines being undefined');
     }

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -13,19 +13,22 @@ export class ProductionManager {
   }
 
   createProduction(newProduction: NewProduction): Production | undefined {
-    if (!this.getProduction(newProduction.name)) {
+    const productionId: string = (this.productions.length + 1).toString();
+    if (!this.getProduction(productionId)) {
       const newProductionLines: Line[] = [];
 
       for (const line of newProduction.lines) {
         const newProductionLine: Line = {
           name: line.name,
-          id: '',
+          smbid: '',
           connections: {}
         };
         newProductionLines.push(newProductionLine);
       }
+
       const production: Production = {
         name: newProduction.name,
+        productionid: productionId,
         lines: newProductionLines
       };
       if (production) {
@@ -38,7 +41,7 @@ export class ProductionManager {
       }
     } else {
       throw new Error(
-        `Create production failed, Production ${newProduction.name} already exists`
+        `Create production failed, Production ${newProduction} already exists`
       );
     }
   }
@@ -47,9 +50,9 @@ export class ProductionManager {
     return this.productions;
   }
 
-  getProduction(productionName: string): Production | undefined {
+  getProduction(productionid: string): Production | undefined {
     const matchedProduction = this.productions.find(
-      (production) => production.name === productionName
+      (production) => production.productionid === productionid
     );
     if (matchedProduction) {
       return matchedProduction;
@@ -74,15 +77,15 @@ export class ProductionManager {
   }
 
   setLineId(
-    productionName: string,
+    productionid: string,
     lineName: string,
-    lineId: string
+    lineSmbId: string
   ): Line | undefined {
-    const matchedProduction = this.getProduction(productionName);
+    const matchedProduction = this.getProduction(productionid);
     if (matchedProduction) {
       const line = this.getLine(matchedProduction.lines, lineName);
       if (line) {
-        line.id = lineId;
+        line.smbid = lineSmbId;
         return line;
       } else {
         return undefined;
@@ -101,13 +104,13 @@ export class ProductionManager {
   }
 
   addConnectionToLine(
-    productionName: string,
+    productionId: string,
     lineName: string,
     userName: string,
     endpointDescription: SmbEndpointDescription,
     endpointId: string
   ): void {
-    const production = this.getProduction(productionName);
+    const production = this.getProduction(productionId);
     if (production) {
       const matchedLine = production.lines.find(
         (line) => line.name === lineName
@@ -120,7 +123,7 @@ export class ProductionManager {
       }
     } else {
       throw new Error(
-        `Adding connection failed, Production ${productionName} does not exist`
+        `Adding connection failed, Production ${productionId} does not exist`
       );
     }
   }


### PR DESCRIPTION
Creating a production now returns  {productionId:string}.
Updated the unittests for the production_manager class to match the new logic.
