### PR TITLE
feat: session id to find correct line when doing patch request

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -4,6 +4,7 @@ export type NewProduction = Static<typeof NewProduction>;
 export type Production = Static<typeof Production>;
 export type ProductionResponse = Static<typeof ProductionResponse>;
 export type Line = Static<typeof Line>;
+export type LineResponse = Static<typeof LineResponse>;
 export type SmbEndpointDescription = Static<typeof SmbEndpointDescription>;
 export type DetailedConference = Static<typeof DetailedConference>;
 
@@ -139,6 +140,7 @@ export const Production = Type.Object({
   lines: Type.Array(
     Type.Object({
       name: Type.String(),
+      id: Type.String(),
       smbid: Type.String(),
       connections: Connections
     })
@@ -149,8 +151,15 @@ export const ProductionResponse = Type.Object({
   productionid: Type.String()
 });
 
+export const LineResponse = Type.Object({
+  name: Type.String(),
+  id: Type.String(),
+  sessionid: Type.String() // SMB endpoint id
+});
+
 export const Line = Type.Object({
   name: Type.String(),
+  id: Type.String(),
   smbid: Type.String(),
   connections: Connections
 });

--- a/src/production_manager.test.ts
+++ b/src/production_manager.test.ts
@@ -122,6 +122,7 @@ describe('production_manager', () => {
       lines: [
         {
           name: 'linename',
+          id: '1',
           smbid: '',
           connections: {}
         }
@@ -182,6 +183,7 @@ describe('production_manager', () => {
       lines: [
         {
           name: 'linename1',
+          id: '1',
           smbid: '',
           connections: {}
         }
@@ -194,6 +196,7 @@ describe('production_manager', () => {
       lines: [
         {
           name: 'linename2',
+          id: '1',
           smbid: '',
           connections: {}
         }
@@ -206,7 +209,7 @@ describe('production_manager', () => {
       production1,
       production2
     ]);
-    productionManagerTest.deleteProduction('productionname1');
+    productionManagerTest.deleteProduction('1');
     expect(productionManagerTest.getProductions()).toStrictEqual([production2]);
   });
 });
@@ -226,11 +229,11 @@ describe('production_manager', () => {
 
     const production = productionManagerTest.createProduction(newProduction);
     expect(productionManagerTest.getProductions()).toStrictEqual([production]);
-    productionManagerTest.deleteProduction('productionname');
+    productionManagerTest.deleteProduction('1');
     expect(productionManagerTest.getProductions()).toStrictEqual([]);
-    expect(
-      productionManagerTest.deleteProduction('productionname')
-    ).toStrictEqual(undefined);
+    expect(productionManagerTest.deleteProduction('1')).toStrictEqual(
+      undefined
+    );
   });
 });
 
@@ -251,7 +254,7 @@ describe('production_manager', () => {
     const lineIdBefore =
       productionManagerTest.getProduction('1')?.lines[0].smbid;
     expect(lineIdBefore).toStrictEqual('');
-    productionManagerTest.setLineId('1', 'linename', 'newLineId');
+    productionManagerTest.setLineId('1', '1', 'newLineId');
     const lineIdAfter =
       productionManagerTest.getProduction('1')?.lines[0].smbid;
     expect(lineIdAfter).toStrictEqual('newLineId');
@@ -279,7 +282,7 @@ describe('production_manager', () => {
       name: 'productionname',
       lines: [
         {
-          name: 'linename'
+          name: 'linename_addConnection'
         }
       ]
     };
@@ -287,10 +290,10 @@ describe('production_manager', () => {
     productionManagerTest.createProduction(newProduction);
     productionManagerTest.addConnectionToLine(
       '1',
-      'linename',
-      'username',
+      '1',
       SmbEndpointDescriptionMock,
-      'endpoinId'
+      'endpointId',
+      'sessionId'
     );
     const productionLines = productionManagerTest.getProduction('1')?.lines;
     if (!productionLines) {
@@ -298,13 +301,11 @@ describe('production_manager', () => {
     }
     const endpointDescription = productionManagerTest.getLine(
       productionLines,
-      'linename'
-    )?.connections['username'].sessionDescription;
-    const endpointId = productionManagerTest.getLine(
-      productionLines,
-      'linename'
-    )?.connections['username'].endpointId;
+      '1'
+    )?.connections['sessionId'].sessionDescription;
+    const endpointId = productionManagerTest.getLine(productionLines, '1')
+      ?.connections['sessionId'].endpointId;
     expect(endpointDescription).toStrictEqual(SmbEndpointDescriptionMock);
-    expect(endpointId).toStrictEqual('endpoinId');
+    expect(endpointId).toStrictEqual('endpointId');
   });
 });

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -17,9 +17,12 @@ export class ProductionManager {
     if (!this.getProduction(productionId)) {
       const newProductionLines: Line[] = [];
 
+      let index = 0;
       for (const line of newProduction.lines) {
+        index++;
         const newProductionLine: Line = {
           name: line.name,
+          id: index.toString(),
           smbid: '',
           connections: {}
         };
@@ -61,13 +64,13 @@ export class ProductionManager {
     }
   }
 
-  deleteProduction(productionName: string): string | undefined {
+  deleteProduction(productionId: string): string | undefined {
     const matchedProductionIndex: number = this.productions.findIndex(
-      (production) => production.name === productionName
+      (production) => production.productionid === productionId
     );
     if (matchedProductionIndex != -1) {
       if (this.productions.splice(matchedProductionIndex, 1)) {
-        return productionName;
+        return productionId;
       } else {
         return undefined;
       }
@@ -78,12 +81,12 @@ export class ProductionManager {
 
   setLineId(
     productionid: string,
-    lineName: string,
+    lineId: string,
     lineSmbId: string
   ): Line | undefined {
     const matchedProduction = this.getProduction(productionid);
     if (matchedProduction) {
-      const line = this.getLine(matchedProduction.lines, lineName);
+      const line = this.getLine(matchedProduction.lines, lineId);
       if (line) {
         line.smbid = lineSmbId;
         return line;
@@ -95,8 +98,8 @@ export class ProductionManager {
     }
   }
 
-  getLine(lines: Line[], lineName: string): Line | undefined {
-    const matchedLine = lines.find((line) => line.name === lineName);
+  getLine(lines: Line[], lineId: string): Line | undefined {
+    const matchedLine = lines.find((line) => line.id === lineId);
     if (matchedLine) {
       return matchedLine;
     }
@@ -105,21 +108,23 @@ export class ProductionManager {
 
   addConnectionToLine(
     productionId: string,
-    lineName: string,
-    userName: string,
+    lineId: string,
     endpointDescription: SmbEndpointDescription,
-    endpointId: string
+    endpointId: string,
+    sessionId: string
   ): void {
     const production = this.getProduction(productionId);
     if (production) {
-      const matchedLine = production.lines.find(
-        (line) => line.name === lineName
-      );
+      const matchedLine = production.lines.find((line) => line.id === lineId);
       if (matchedLine) {
-        matchedLine.connections[userName] = {
+        matchedLine.connections[sessionId] = {
           sessionDescription: endpointDescription,
           endpointId: endpointId
         };
+      } else {
+        throw new Error(
+          `Adding connection failed, Line ${lineId} does not exist`
+        );
       }
     } else {
       throw new Error(
@@ -129,22 +134,20 @@ export class ProductionManager {
   }
 
   removeConnectionFromLine(
-    productionName: string,
-    lineName: string,
-    userName: string
+    productionId: string,
+    lineId: string,
+    sessionId: string
   ): string | undefined {
-    const production = this.getProduction(productionName);
+    const production = this.getProduction(productionId);
     if (production) {
-      const matchedLine = production.lines.find(
-        (line) => line.name === lineName
-      );
+      const matchedLine = production.lines.find((line) => line.id === lineId);
       if (matchedLine?.connections) {
-        delete matchedLine.connections[userName];
-        return userName;
+        delete matchedLine.connections[sessionId];
+        return sessionId;
       }
     } else {
       throw new Error(
-        `Deleting connection failed, Production ${productionName} does not exist`
+        `Deleting connection failed, Production ${productionId} does not exist`
       );
     }
   }


### PR DESCRIPTION
When creating a new connection using post request, a session id is provided alongside the sdp in the response. This session  id should be used in the patch request (ex. /productions/1/lines/1/session/4a78855f-06ec-468e-b5b2-c38407fe6cb7) to finalize the connection.

-Updated help functions to use id instead of name as identifier
-Updated unit tests to match new logic