### PR TITLE
feat: long poll api endpoint and user manager

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -7,6 +7,8 @@ export type Line = Static<typeof Line>;
 export type LineResponse = Static<typeof LineResponse>;
 export type SmbEndpointDescription = Static<typeof SmbEndpointDescription>;
 export type DetailedConference = Static<typeof DetailedConference>;
+export type Endpoint = Static<typeof Endpoint>;
+export type User = Static<typeof User>;
 
 export const Audio = Type.Object({
   'relay-type': Type.Array(
@@ -129,37 +131,39 @@ export const SmbEndpointDescription = Type.Object({
 
 export const Endpoint = Type.Object({
   endpointId: Type.String(),
-  sessionDescription: SmbEndpointDescription
+  sessionDescription: SmbEndpointDescription,
+  isActive: Type.Boolean()
 });
 
 export const Connections = Type.Record(Type.String(), Endpoint);
 
+export const Line = Type.Object({
+  name: Type.String(),
+  id: Type.String(),
+  smbid: Type.String(),
+  connections: Connections,
+  users: Type.Any()
+});
+
 export const Production = Type.Object({
   name: Type.String(),
   productionid: Type.String(),
-  lines: Type.Array(
-    Type.Object({
-      name: Type.String(),
-      id: Type.String(),
-      smbid: Type.String(),
-      connections: Connections
-    })
-  )
+  lines: Type.Array(Line)
 });
 
 export const ProductionResponse = Type.Object({
   productionid: Type.String()
 });
 
+export const User = Type.Object({
+  name: Type.String(),
+  sessionid: Type.String(),
+  isActive: Type.Boolean()
+});
+
 export const LineResponse = Type.Object({
   name: Type.String(),
   id: Type.String(),
-  sessionid: Type.String() // SMB endpoint id
-});
-
-export const Line = Type.Object({
-  name: Type.String(),
-  id: Type.String(),
-  smbid: Type.String(),
-  connections: Connections
+  smbconferenceid: Type.String(),
+  participants: Type.Array(User)
 });

--- a/src/production_manager.test.ts
+++ b/src/production_manager.test.ts
@@ -1,4 +1,5 @@
 import { ProductionManager } from './production_manager';
+import { UserManager } from './user_manager';
 import { NewProduction, Production, SmbEndpointDescription } from './models';
 
 const SmbEndpointDescriptionMock: SmbEndpointDescription = {
@@ -124,7 +125,8 @@ describe('production_manager', () => {
           name: 'linename',
           id: '1',
           smbid: '',
-          connections: {}
+          connections: {},
+          users: new UserManager()
         }
       ]
     };
@@ -185,7 +187,8 @@ describe('production_manager', () => {
           name: 'linename1',
           id: '1',
           smbid: '',
-          connections: {}
+          connections: {},
+          users: new UserManager()
         }
       ]
     };
@@ -198,7 +201,8 @@ describe('production_manager', () => {
           name: 'linename2',
           id: '1',
           smbid: '',
-          connections: {}
+          connections: {},
+          users: new UserManager()
         }
       ]
     };
@@ -299,13 +303,16 @@ describe('production_manager', () => {
     if (!productionLines) {
       fail('Test failed due to productionLines being undefined');
     }
-    const endpointDescription = productionManagerTest.getLine(
-      productionLines,
-      '1'
-    )?.connections['sessionId'].sessionDescription;
-    const endpointId = productionManagerTest.getLine(productionLines, '1')
-      ?.connections['sessionId'].endpointId;
-    expect(endpointDescription).toStrictEqual(SmbEndpointDescriptionMock);
-    expect(endpointId).toStrictEqual('endpointId');
+    const line = productionManagerTest.getLine(productionLines, '1');
+    expect(line);
+
+    const endpoint = line?.connections['sessionId'];
+    expect(endpoint);
+
+    expect(endpoint?.sessionDescription).toStrictEqual(
+      SmbEndpointDescriptionMock
+    );
+    expect(endpoint?.endpointId).toStrictEqual('endpointId');
+    expect(endpoint?.isActive).toStrictEqual(true);
   });
 });

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -5,6 +5,8 @@ import {
   SmbEndpointDescription
 } from './models';
 
+import { UserManager } from './user_manager';
+
 export class ProductionManager {
   private productions: Production[];
 
@@ -24,7 +26,8 @@ export class ProductionManager {
           name: line.name,
           id: index.toString(),
           smbid: '',
-          connections: {}
+          connections: {},
+          users: new UserManager()
         };
         newProductionLines.push(newProductionLine);
       }
@@ -119,7 +122,8 @@ export class ProductionManager {
       if (matchedLine) {
         matchedLine.connections[sessionId] = {
           sessionDescription: endpointDescription,
-          endpointId: endpointId
+          endpointId: endpointId,
+          isActive: true
         };
       } else {
         throw new Error(
@@ -144,6 +148,10 @@ export class ProductionManager {
       if (matchedLine?.connections) {
         delete matchedLine.connections[sessionId];
         return sessionId;
+      } else {
+        throw new Error(
+          `Deleting connection failed, Line ${lineId} does not exist`
+        );
       }
     } else {
       throw new Error(

--- a/src/user_manager.ts
+++ b/src/user_manager.ts
@@ -1,0 +1,42 @@
+import { User } from './models';
+import { EventEmitter } from 'events';
+
+interface UserManagerInterface {
+  getUsers(): User[];
+  addUser(user: User): void;
+  removeUser(sessionId: string): string | undefined;
+}
+
+export class UserManager implements UserManagerInterface {
+  private users: User[];
+  changeEmitter: EventEmitter;
+  constructor() {
+    this.users = [];
+    this.changeEmitter = new EventEmitter();
+  }
+
+  getUsers(): User[] {
+    return this.users;
+  }
+
+  addUser(user: User): number {
+    this.changeEmitter.emit('change');
+    return this.users.push(user);
+  }
+
+  removeUser(sessionId: string): string | undefined {
+    this.changeEmitter.emit('change');
+    const matchedUserIndex: number = this.users.findIndex(
+      (user) => user.sessionid === sessionId
+    );
+    if (matchedUserIndex != -1) {
+      if (this.users.splice(matchedUserIndex, 1)) {
+        return sessionId;
+      } else {
+        return undefined;
+      }
+    } else {
+      return undefined;
+    }
+  }
+}


### PR DESCRIPTION
-Added a user manager class. One instance of this class is created for every line. There is an event emitter which triggers every time a add/remove function is called on the user manager instance.
-Added a heartbeat endpoint that only resolves if there is a change to the list of users. I am thinking we can use this to implement a long polling from the client. The client will make one request that will linger until it received an updated user list. The client will then immediately make a new request.
-Updated unit tests