### PR TITLE
feat: use ssrc-rewrite mode instead of mixed mode for audio channels

### DIFF
--- a/src/api_productions_core_functions.ts
+++ b/src/api_productions_core_functions.ts
@@ -6,6 +6,7 @@ import { SmbProtocol } from './smb';
 import { CoreFunctionsInterface } from './api_productions_core_functions_interface';
 import { ConnectionQueue } from './connection_queue';
 import { ProductionManager } from './production_manager';
+import { v4 as uuidv4 } from 'uuid';
 
 export class CoreFunctions implements CoreFunctionsInterface {
   private productionManager: ProductionManager;
@@ -35,9 +36,9 @@ export class CoreFunctions implements CoreFunctionsInterface {
     endpoint.audio.ssrcs.forEach((ssrcsNr) => {
       ssrcs.push({
         ssrc: ssrcsNr.toString(),
-        cname: `audioCName`,
-        mslabel: `$audioMSLabel`,
-        label: `audioLabel`
+        cname: uuidv4(),
+        mslabel: uuidv4(),
+        label: uuidv4()
       });
     });
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -71,7 +71,10 @@ export class Connection {
     let msidSemanticToken = 'feedbackvideomslabel';
     if (this.mediaStreams) {
       if (this.mediaStreams.audio.ssrcs.length !== 0) {
-        msidSemanticToken = `${this.mediaStreams.audio.ssrcs[0].mslabel}`;
+        const mslabels = this.mediaStreams.audio.ssrcs.map(
+          (element) => element.mslabel
+        );
+        msidSemanticToken = `${mslabels.join(' ')}`;
       }
     }
 

--- a/src/smb.ts
+++ b/src/smb.ts
@@ -59,7 +59,7 @@ export class SmbProtocol {
     };
 
     if (audio) {
-      request['audio'] = { 'relay-type': 'mixed' };
+      request['audio'] = { 'relay-type': 'ssrc-rewrite' };
     }
     if (data) {
       request['data'] = {};


### PR DESCRIPTION
- Create endpoint with ssrc-rewrite mode instead of mixed
- Use random uuids as mslabel, label and cname instead of hard coded values
- Append all msids to the msid-sematic attribute in the generated SDP offer