### PR TITLE
fix: faulty setting of id

### DIFF
--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -50,7 +50,10 @@ export class ProductionManager extends EventEmitter {
   }
 
   createProduction(newProduction: NewProduction): Production | undefined {
-    const productionId: string = (this.productions.length + 1).toString();
+    const productionIds = this.productions.map((production) =>
+      parseInt(production.productionid, 10)
+    );
+    const productionId = (Math.max(...productionIds, 0) + 1).toString();
     if (!this.getProduction(productionId)) {
       const newProductionLines: Line[] = [];
 


### PR DESCRIPTION
We assigned the prod id based on list length + 1. This causes problems if one item is deleted and list length decreases because the assigned id will then be that of an already existing id which causes the logic to exit prod creation.