### PR TITLE
refactor: rename User model to UserResponse

### DIFF
--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -5,7 +5,7 @@ import {
   Production,
   LineResponse,
   SmbEndpointDescription,
-  User,
+  UserResponse,
   ProductionResponse,
   DetailedProductionResponse,
   UserSession
@@ -193,7 +193,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
         );
         const line = productionManager.requireLine(production.lines, lineid);
 
-        const participantlist: User[] = productionManager.getUsersForLine(
+        const participantlist = productionManager.getUsersForLine(
           productionid,
           line.id
         );
@@ -402,14 +402,14 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
   //Long poll endpoint
   fastify.post<{
     Params: { productionid: string; lineid: string; sessionid: string };
-    Reply: User[] | string;
+    Reply: UserResponse[] | string;
   }>(
     '/productions/:productionid/lines/:lineid/participants',
     {
       schema: {
         description: 'Long Poll Endpoint to get participant list.',
         response: {
-          200: Type.Array(User)
+          200: Type.Array(UserResponse)
         }
       }
     },

--- a/src/models.ts
+++ b/src/models.ts
@@ -11,7 +11,7 @@ export type LineResponse = Static<typeof LineResponse>;
 export type SmbEndpointDescription = Static<typeof SmbEndpointDescription>;
 export type DetailedConference = Static<typeof DetailedConference>;
 export type Endpoint = Static<typeof Endpoint>;
-export type User = Static<typeof User>;
+export type UserResponse = Static<typeof UserResponse>;
 export type UserSession = Static<typeof UserSession>;
 
 export const Audio = Type.Object({
@@ -140,7 +140,7 @@ export const Endpoint = Type.Object({
 
 export const Connections = Type.Record(Type.String(), Endpoint);
 
-export const User = Type.Object({
+export const UserResponse = Type.Object({
   name: Type.String(),
   sessionid: Type.String(),
   isActive: Type.Boolean()
@@ -167,7 +167,7 @@ export const LineResponse = Type.Object({
   name: Type.String(),
   id: Type.String(),
   smbconferenceid: Type.String(),
-  participants: Type.Array(User)
+  participants: Type.Array(UserResponse)
 });
 
 export const Production = Type.Object({

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -5,8 +5,8 @@ import {
   Production,
   Line,
   SmbEndpointDescription,
-  UserSession,
-  User
+  UserResponse,
+  UserSession
 } from './models';
 import { assert } from './utils';
 import dbManager from './db_manager';
@@ -238,7 +238,7 @@ export class ProductionManager extends EventEmitter {
     return undefined;
   }
 
-  getUsersForLine(productionId: string, lineId: string): User[] {
+  getUsersForLine(productionId: string, lineId: string): UserResponse[] {
     return Object.entries(this.userSessions).flatMap(
       ([sessionid, userSession]) => {
         if (


### PR DESCRIPTION
When I introduced the UserSession model I wanted to leave the old `User` model as is for the API compatibility, because we used it for the response. But having worked with them now I think the `UserSession` model is the main one and the UserResponse is a better name.

This PR is not important and can wait until after #71 is merged. I just thought it was easier to make the PR than to make an issue to remember to make the PR.