### PR TITLE
feat: replace productionid str with auto-incrementing _id number

### DIFF
--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -2,7 +2,6 @@ import { Type } from '@sinclair/typebox';
 import { FastifyPluginCallback } from 'fastify';
 import {
   NewProduction,
-  Production,
   LineResponse,
   SmbEndpointDescription,
   User,
@@ -65,7 +64,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
         if (production) {
           const productionResponse: ProductionResponse = {
             name: production.name,
-            productionid: production.productionid
+            productionid: production._id.toString()
           };
           reply.code(200).send(productionResponse);
         } else {
@@ -95,9 +94,9 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
       try {
         const productions = await productionManager.getProductions(50);
         reply.code(200).send(
-          productions.map(({ name, productionid }) => ({
+          productions.map(({ _id, name }) => ({
             name,
-            productionid
+            productionid: _id.toString()
           }))
         );
       } catch (err) {
@@ -124,13 +123,13 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
     async (request, reply) => {
       try {
         const production = await productionManager.requireProduction(
-          request.params.productionid
+          parseInt(request.params.productionid, 10)
         );
         const allLinesResponse: LineResponse[] =
           coreFunctions.getAllLinesResponse(production);
         const productionResponse: DetailedProductionResponse = {
           name: production.name,
-          productionid: production.productionid,
+          productionid: production._id.toString(),
           lines: allLinesResponse
         };
         reply.code(200).send(productionResponse);
@@ -158,7 +157,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
     async (request, reply) => {
       try {
         const production = await productionManager.requireProduction(
-          request.params.productionid
+          parseInt(request.params.productionid, 10)
         );
         const allLinesResponse: LineResponse[] =
           coreFunctions.getAllLinesResponse(production);
@@ -188,7 +187,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
       try {
         const { productionid, lineid } = request.params;
         const production = await productionManager.requireProduction(
-          productionid
+          parseInt(productionid, 10)
         );
         const line = productionManager.requireLine(production.lines, lineid);
 
@@ -233,7 +232,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
         const { lineid, productionid, username } = request.params;
         const sessionId: string = uuidv4();
         const production = await productionManager.requireProduction(
-          productionid
+          parseInt(productionid, 10)
         );
 
         await coreFunctions.createConferenceForLine(
@@ -302,7 +301,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
       try {
         const { productionid, lineid, sessionid } = request.params;
         const production = await productionManager.requireProduction(
-          productionid
+          parseInt(productionid, 10)
         );
         const line = productionManager.requireLine(production.lines, lineid);
 

--- a/src/api_productions_core_functions.ts
+++ b/src/api_productions_core_functions.ts
@@ -202,13 +202,13 @@ export class CoreFunctions {
       const newConferenceId = await smb.allocateConference(smbServerUrl);
       if (
         !(await this.productionManager.setLineId(
-          production.productionid,
+          production._id,
           line.id,
           newConferenceId
         ))
       ) {
         throw new Error(
-          `Failed to set line smb id for line ${line.id} in production ${production.productionid}`
+          `Failed to set line smb id for line ${line.id} in production ${production._id}`
         );
       }
     }
@@ -233,7 +233,7 @@ export class CoreFunctions {
         id,
         smbconferenceid,
         participants: this.productionManager.getUsersForLine(
-          production.productionid,
+          production._id.toString(),
           id
         )
       })

--- a/src/models.ts
+++ b/src/models.ts
@@ -171,8 +171,8 @@ export const LineResponse = Type.Object({
 });
 
 export const Production = Type.Object({
+  _id: Type.Number(),
   name: Type.String(),
-  productionid: Type.String(),
   lines: Type.Array(Line)
 });
 

--- a/src/production_manager.test.ts
+++ b/src/production_manager.test.ts
@@ -17,8 +17,8 @@ const newProduction: NewProduction = {
 };
 
 const existingProduction: Production = {
+  _id: 1,
   name: 'productionname',
-  productionid: '1',
   lines: [
     {
       name: 'linename',
@@ -85,7 +85,6 @@ const SmbEndpointDescriptionMock: SmbEndpointDescription = {
 jest.mock('./db_manager', () => ({
   addProduction: jest.fn(),
   getProduction: jest.fn(),
-  getProductionCount: jest.fn(),
   getProductions: jest.fn(),
   deleteProduction: jest.fn()
 }));
@@ -95,25 +94,16 @@ beforeEach(() => {
 });
 
 describe('production_manager', () => {
-  it('creates a production object and save it to the class instance', async () => {
+  it('calls the dbManager when you try to create a production', async () => {
     const { getProduction } = jest.requireMock('./db_manager');
     getProduction.mockReturnValueOnce(undefined).mockReturnValue(newProduction);
 
     const productionManagerTest = new ProductionManager();
 
-    const spyGetProductionCount = jest.spyOn(dbManager, 'getProductionCount');
     const spyAddProduction = jest.spyOn(dbManager, 'addProduction');
-    const spyGetProduction = jest.spyOn(dbManager, 'getProduction');
 
-    const production = await productionManagerTest.createProduction(
-      newProduction
-    );
+    await productionManagerTest.createProduction(newProduction);
     expect(spyAddProduction).toHaveBeenCalledTimes(1);
-    expect(spyGetProductionCount).toHaveBeenCalledTimes(1);
-    expect(spyGetProduction).toHaveBeenCalledTimes(1);
-    expect(production).not.toBe(undefined);
-    expect(production?.name).toStrictEqual('productionname');
-    expect(production?.lines[0].name).toStrictEqual('linename');
   });
 });
 
@@ -161,36 +151,16 @@ describe('production_manager', () => {
 
     const productionManagerTest = new ProductionManager();
 
-    const nonExistentProduction = await productionManagerTest.getProduction(
-      'null'
-    );
+    const nonExistentProduction = await productionManagerTest.getProduction(-1);
     expect(nonExistentProduction).toStrictEqual(undefined);
   });
 });
 
 describe('production_manager', () => {
   it('deleting production object removes it from class instance', async () => {
-    const newProduction1: NewProduction = {
-      name: 'productionname1',
-      lines: [
-        {
-          name: 'linename1'
-        }
-      ]
-    };
-
-    const newProduction2: NewProduction = {
-      name: 'productionname2',
-      lines: [
-        {
-          name: 'linename2'
-        }
-      ]
-    };
-
     const production1: Production = {
+      _id: 1,
       name: 'productionname1',
-      productionid: '1',
       lines: [
         {
           name: 'linename1',
@@ -201,8 +171,8 @@ describe('production_manager', () => {
     };
 
     const production2: Production = {
+      _id: 2,
       name: 'productionname2',
-      productionid: '2',
       lines: [
         {
           name: 'linename2',
@@ -212,14 +182,9 @@ describe('production_manager', () => {
       ]
     };
 
-    const {
-      getProduction,
-      getProductionCount,
-      getProductions,
-      deleteProduction
-    } = jest.requireMock('./db_manager');
+    const { getProduction, getProductions, deleteProduction } =
+      jest.requireMock('./db_manager');
     getProduction.mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
-    getProductionCount.mockReturnValueOnce(0).mockReturnValueOnce(1);
     getProductions
       .mockReturnValueOnce([production1, production2])
       .mockReturnValueOnce([production2]);
@@ -227,12 +192,6 @@ describe('production_manager', () => {
 
     const productionManagerTest = new ProductionManager();
 
-    expect(
-      await productionManagerTest.createProduction(newProduction1)
-    ).toStrictEqual(production1);
-    expect(
-      await productionManagerTest.createProduction(newProduction2)
-    ).toStrictEqual(production2);
     expect(await productionManagerTest.getProductions()).toStrictEqual([
       production1,
       production2
@@ -278,7 +237,7 @@ describe('production_manager', () => {
       'endpointId',
       SmbEndpointDescriptionMock
     );
-    const production = await productionManagerTest.getProduction('1');
+    const production = await productionManagerTest.getProduction(1);
     const productionLines = production?.lines;
     if (!productionLines) {
       fail('Test failed due to productionLines being undefined');

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -52,20 +52,9 @@ export class ProductionManager extends EventEmitter {
     }
   }
 
-  async getProductionCount(): Promise<number> {
-    return await dbManager.getProductionCount();
-  }
-
   async createProduction(
     newProduction: NewProduction
   ): Promise<Production | undefined> {
-    const productionCount = await this.getProductionCount();
-    const productionId = (productionCount + 1).toString();
-
-    assert(
-      !(await this.getProduction(productionId)),
-      `Create production failed, Production with id "${productionId}" already exists`
-    );
     const newProductionLines: Line[] = [];
 
     let index = 0;
@@ -79,27 +68,19 @@ export class ProductionManager extends EventEmitter {
       newProductionLines.push(newProductionLine);
     }
 
-    const production: Production = {
-      name: newProduction.name,
-      productionid: productionId,
-      lines: newProductionLines
-    };
-    if (production) {
-      await dbManager.addProduction(production);
-      return production;
-    }
+    return dbManager.addProduction(newProduction.name, newProductionLines);
   }
 
   async getProductions(limit = 0): Promise<Production[]> {
     return dbManager.getProductions(limit);
   }
 
-  async getProduction(productionid: string): Promise<Production | undefined> {
-    return dbManager.getProduction(productionid);
+  async getProduction(id: number): Promise<Production | undefined> {
+    return dbManager.getProduction(id);
   }
 
-  async requireProduction(productionid: string): Promise<Production> {
-    const production = await this.getProduction(productionid);
+  async requireProduction(id: number): Promise<Production> {
+    const production = await this.getProduction(id);
     assert(production, 'Trying to get a production that does not exist');
     return production;
   }
@@ -112,7 +93,7 @@ export class ProductionManager extends EventEmitter {
   }
 
   async setLineId(
-    productionid: string,
+    productionid: number,
     lineId: string,
     lineSmbId: string
   ): Promise<Line | undefined> {


### PR DESCRIPTION
I made a new method that runs a command to bump a "counter" (new collection) for a given collection and returns the result, to manually handle the auto-incrementing id.

The new id doesn't have to be named _id and doesn't have to be a number. We can change it back to how it was stored. But then MongoDB would create it's own ObjectId for _id again. Arguably with the parseInt logic added here that might be nicer.

If we do go with this, we have to prune old data, since they are using the wrong type for the _id field.

You can do that from `mongosh` (cli tool):

```mongosh
use intercom-manager;
db.dropDatabase()
```

The database and collections will re-create next time we push to them, so no need to to that.


I removed some tests because createProduction is now just a wrapper around dbManager.createProduction, which we mock. And if I would have mocked that functionality we would just be testing the mocks, which would be pointless.