### PR TITLE
feat: use api-key for symphony if provided

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ Intercom solution powered by Symphony Media Bridge. This is the Intercom manager
 | --------------------------- | --------------------------------------------------------------------------------- |
 | `PORT`                      | Intercom-Manager API port                                                         |
 | `SMB_ADDRESS`               | The address:port of the Symphony Media Bridge instance                            |
+| `SMB_APIKEY`                | When set, provide this API key for the Symphony Media Bridge (optional)           |
 | `MONGODB_CONNECTION_STRING` | MongoDB connection string (default: `mongodb://localhost:27017/intercom-manager`) |
 
 ## Installation / Usage

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,6 +41,7 @@ export interface ApiOptions {
   title: string;
   smbServerBaseUrl: string;
   endpointIdleTimeout: string;
+  smbServerApiKey?: string;
 }
 
 export default async (opts: ApiOptions) => {
@@ -70,7 +71,8 @@ export default async (opts: ApiOptions) => {
   api.register(await getApiProductions(), {
     prefix: 'api/v1',
     smbServerBaseUrl: opts.smbServerBaseUrl,
-    endpointIdleTimeout: opts.endpointIdleTimeout
+    endpointIdleTimeout: opts.endpointIdleTimeout,
+    smbServerApiKey: opts.smbServerApiKey
   });
 
   return api;

--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -31,6 +31,7 @@ export function checkUserStatus() {
 export interface ApiProductionsOptions {
   smbServerBaseUrl: string;
   endpointIdleTimeout: string;
+  smbServerApiKey?: string;
 }
 
 const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
@@ -43,6 +44,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
     opts.smbServerBaseUrl
   ).toString();
   const smb = new SmbProtocol();
+  const smbServerApiKey = opts.smbServerApiKey || '';
 
   fastify.post<{
     Body: NewProduction;
@@ -236,6 +238,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
         const smbConferenceId = await coreFunctions.createConferenceForLine(
           smb,
           smbServerUrl,
+          smbServerApiKey,
           productionId,
           lineId
         );
@@ -244,6 +247,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
         const endpoint = await coreFunctions.createEndpoint(
           smb,
           smbServerUrl,
+          smbServerApiKey,
           smbConferenceId,
           endpointId,
           true,
@@ -330,6 +334,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
         await coreFunctions.handleAnswerRequest(
           smb,
           smbServerUrl,
+          smbServerApiKey,
           line.smbConferenceId,
           endpointId,
           connectionEndpointDescription,

--- a/src/api_productions_core_functions.ts
+++ b/src/api_productions_core_functions.ts
@@ -76,6 +76,7 @@ export class CoreFunctions {
   async createEndpoint(
     smb: SmbProtocol,
     smbServerUrl: string,
+    smbServerApiKey: string,
     lineId: string,
     endpointId: string,
     audio: boolean,
@@ -88,7 +89,8 @@ export class CoreFunctions {
       endpointId,
       audio,
       data,
-      endpointIdleTimeout
+      endpointIdleTimeout,
+      smbServerApiKey
     );
     return endpoint;
   }
@@ -96,6 +98,7 @@ export class CoreFunctions {
   async handleAnswerRequest(
     smb: SmbProtocol,
     smbServerUrl: string,
+    smbServerApiKey: string,
     lineId: string,
     endpointId: string,
     endpointDescription: SmbEndpointDescription,
@@ -184,7 +187,8 @@ export class CoreFunctions {
       smbServerUrl,
       lineId,
       endpointId,
-      endpointDescription
+      endpointDescription,
+      smbServerApiKey
     );
   }
 
@@ -198,10 +202,14 @@ export class CoreFunctions {
   private async createConference(
     smb: SmbProtocol,
     smbServerUrl: string,
+    smbServerApiKey: string,
     productionId: string,
     lineId: string
   ): Promise<string> {
-    const activeLines: string[] = await smb.getConferences(smbServerUrl);
+    const activeLines: string[] = await smb.getConferences(
+      smbServerUrl,
+      smbServerApiKey
+    );
 
     const production = await this.productionManager.requireProduction(
       parseInt(productionId, 10)
@@ -213,7 +221,10 @@ export class CoreFunctions {
       return line.smbConferenceId;
     }
 
-    const newConferenceId = await smb.allocateConference(smbServerUrl);
+    const newConferenceId = await smb.allocateConference(
+      smbServerUrl,
+      smbServerApiKey
+    );
 
     if (
       !(await this.productionManager.setLineId(
@@ -233,11 +244,18 @@ export class CoreFunctions {
   async createConferenceForLine(
     smb: SmbProtocol,
     smbServerUrl: string,
+    smbServerApiKey: string,
     productionId: string,
     lineId: string
   ): Promise<string> {
     const createConf = () =>
-      this.createConference(smb, smbServerUrl, productionId, lineId);
+      this.createConference(
+        smb,
+        smbServerUrl,
+        smbServerApiKey,
+        productionId,
+        lineId
+      );
 
     return this.connectionQueue.queueAsync(createConf);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,8 @@ const PORT = process.env.PORT ? Number(process.env.PORT) : 8000;
   const server = await api({
     title: 'intercom-manager',
     smbServerBaseUrl: SMB_ADDRESS,
-    endpointIdleTimeout: ENDPOINT_IDLE_TIMEOUT_S
+    endpointIdleTimeout: ENDPOINT_IDLE_TIMEOUT_S,
+    smbServerApiKey: process.env.SMB_APIKEY
   });
 
   server.listen({ port: PORT, host: '0.0.0.0' }, (err, address) => {

--- a/src/smb.ts
+++ b/src/smb.ts
@@ -18,11 +18,12 @@ interface BaseAllocationRequest {
 }
 
 export class SmbProtocol {
-  async allocateConference(smbUrl: string): Promise<string> {
+  async allocateConference(smbUrl: string, smbKey: string): Promise<string> {
     const allocateResponse = await fetch(smbUrl, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...(smbKey !== '' && { Authorization: `Bearer ${smbKey}` })
       },
       body: '{}'
     });
@@ -46,7 +47,8 @@ export class SmbProtocol {
     endpointId: string,
     audio: boolean,
     data: boolean,
-    idleTimeout: number
+    idleTimeout: number,
+    smbKey: string
   ): Promise<SmbEndpointDescription> {
     const request: BaseAllocationRequest = {
       action: 'allocate',
@@ -74,7 +76,8 @@ export class SmbProtocol {
     const response = await fetch(url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...(smbKey !== '' && { Authorization: `Bearer ${smbKey}` })
       },
       body: JSON.stringify(request)
     });
@@ -96,7 +99,8 @@ export class SmbProtocol {
     smbUrl: string,
     conferenceId: string,
     endpointId: string,
-    endpointDescription: SmbEndpointDescription
+    endpointDescription: SmbEndpointDescription,
+    smbKey: string
   ): Promise<void> {
     const request = JSON.parse(JSON.stringify(endpointDescription));
     request['action'] = 'configure';
@@ -104,7 +108,8 @@ export class SmbProtocol {
     const response = await fetch(url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...(smbKey !== '' && { Authorization: `Bearer ${smbKey}` })
       },
       body: JSON.stringify(request)
     });
@@ -130,9 +135,12 @@ export class SmbProtocol {
     }
   }
 
-  async getConferences(smbUrl: string): Promise<string[]> {
+  async getConferences(smbUrl: string, smbKey: string): Promise<string[]> {
     const response = await fetch(smbUrl, {
-      method: 'GET'
+      method: 'GET',
+      headers: {
+        ...(smbKey !== '' && { Authorization: `Bearer ${smbKey}` })
+      }
     });
 
     if (!response.ok) {
@@ -145,11 +153,15 @@ export class SmbProtocol {
 
   async getConference(
     smbUrl: string,
-    conferenceId: string
+    conferenceId: string,
+    smbKey: string
   ): Promise<DetailedConference[]> {
     const url = smbUrl + conferenceId;
     const response = await fetch(url, {
-      method: 'GET'
+      method: 'GET',
+      headers: {
+        ...(smbKey !== '' && { Authorization: `Bearer ${smbKey}` })
+      }
     });
 
     if (!response.ok) {


### PR DESCRIPTION
If env variable `SMB_APIKEY` is set provide this key as a Bearer token to the SFU API. This requires that the SFU has been setup with SSL and for example an nginx proxy to validate the token.