### PR TITLE
feat(#95): can rename a line in a production

### DIFF
--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -12,7 +12,9 @@ import {
   SessionResponse,
   SdpAnswer,
   NewProductionLine,
-  ErrorResponse
+  ErrorResponse,
+  PatchLineResponse,
+  PatchLine
 } from './models';
 import { SmbProtocol } from './smb';
 import { ProductionManager } from './production_manager';
@@ -260,6 +262,71 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
             participants: participantlist
           };
           reply.code(200).send(lineResponse);
+        }
+      } catch (err) {
+        reply
+          .code(500)
+          .send('Exception thrown when trying to get line: ' + err);
+      }
+    }
+  );
+
+  fastify.patch<{
+    Params: { productionId: string; lineId: string };
+    Body: PatchLine;
+    Reply: PatchLineResponse | ErrorResponse | string;
+  }>(
+    '/production/:productionId/line/:lineId',
+    {
+      schema: {
+        description: 'Modify an existing Production line.',
+        body: PatchLine,
+        response: {
+          200: PatchLineResponse,
+          400: ErrorResponse,
+          404: ErrorResponse,
+          500: Type.String()
+        }
+      }
+    },
+    async (request, reply) => {
+      try {
+        const { productionId, lineId } = request.params;
+        let production;
+        try {
+          production = await productionManager.requireProduction(
+            parseInt(productionId, 10)
+          );
+        } catch (err) {
+          console.warn(
+            'Trying to patch a production line in a production that does not exist'
+          );
+        }
+        if (!production) {
+          reply
+            .code(404)
+            .send({ message: `Production with id ${productionId} not found` });
+        } else {
+          const line = productionManager.getLine(production.lines, lineId);
+          if (!line) {
+            reply
+              .code(404)
+              .send({ message: `Line with id ${lineId} not found` });
+          } else {
+            const updatedProduction =
+              await productionManager.updateProductionLine(
+                production,
+                lineId,
+                request.body.name
+              );
+            if (!updatedProduction) {
+              reply.code(400).send({
+                message: `Failed to update line with id ${lineId} in production ${productionId}`
+              });
+            } else {
+              reply.code(200).send({ name: request.body.name, id: lineId });
+            }
+          }
         }
       } catch (err) {
         reply

--- a/src/models.ts
+++ b/src/models.ts
@@ -9,6 +9,8 @@ export type DetailedProductionResponse = Static<
 >;
 export type Line = Static<typeof Line>;
 export type LineResponse = Static<typeof LineResponse>;
+export type PatchLine = Static<typeof PatchLine>;
+export type PatchLineResponse = Static<typeof PatchLineResponse>;
 export type SmbEndpointDescription = Static<typeof SmbEndpointDescription>;
 export type DetailedConference = Static<typeof DetailedConference>;
 export type Endpoint = Static<typeof Endpoint>;
@@ -179,6 +181,9 @@ export const LineResponse = Type.Object({
   smbConferenceId: Type.String(),
   participants: Type.Array(UserResponse)
 });
+
+export const PatchLine = Type.Omit(Line, ['id', 'smbConferenceId']);
+export const PatchLineResponse = Type.Omit(Line, ['smbConferenceId']);
 
 export const Production = Type.Object({
   _id: Type.Number(),

--- a/src/production_manager.test.ts
+++ b/src/production_manager.test.ts
@@ -86,6 +86,7 @@ jest.mock('./db_manager', () => ({
   addProduction: jest.fn(),
   getProduction: jest.fn(),
   getProductions: jest.fn(),
+  updateProduction: jest.fn(),
   deleteProduction: jest.fn()
 }));
 
@@ -250,5 +251,81 @@ describe('production_manager', () => {
     expect(userSession?.name).toStrictEqual('userName');
     expect(userSession?.isActive).toStrictEqual(true);
     expect(userSession?.isExpired).toStrictEqual(false);
+  });
+
+  describe('production_manager', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('add a line to a production', async () => {
+      const { getProduction, updateProduction } =
+        jest.requireMock('./db_manager');
+      getProduction.mockReturnValueOnce(structuredClone(existingProduction));
+
+      const productionManagerTest = new ProductionManager();
+      const production = await productionManagerTest.getProduction(1);
+      if (production) {
+        await productionManagerTest.addProductionLine(production, 'newName');
+        expect(updateProduction).toHaveBeenLastCalledWith({
+          _id: 1,
+          name: 'productionname',
+          lines: [
+            {
+              name: 'linename',
+              id: '1',
+              smbConferenceId: 'smbineid'
+            },
+            {
+              name: 'newName',
+              id: '2',
+              smbConferenceId: ''
+            }
+          ]
+        });
+      }
+    });
+
+    it('remove a line from a production', async () => {
+      const { getProduction, updateProduction } =
+        jest.requireMock('./db_manager');
+      getProduction.mockReturnValueOnce(structuredClone(existingProduction));
+      const productionManagerTest = new ProductionManager();
+      const production = await productionManagerTest.getProduction(1);
+      if (production) {
+        await productionManagerTest.deleteProductionLine(production, '1');
+        expect(updateProduction).toHaveBeenLastCalledWith({
+          _id: 1,
+          name: 'productionname',
+          lines: []
+        });
+      }
+    });
+
+    it('change the name of a line in a production', async () => {
+      const { getProduction, updateProduction } =
+        jest.requireMock('./db_manager');
+      getProduction.mockReturnValueOnce(structuredClone(existingProduction));
+      const productionManagerTest = new ProductionManager();
+      const production = await productionManagerTest.getProduction(1);
+      if (production) {
+        await productionManagerTest.updateProductionLine(
+          production,
+          '1',
+          'newName'
+        );
+        expect(updateProduction).toHaveBeenLastCalledWith({
+          _id: 1,
+          name: 'productionname',
+          lines: [
+            {
+              name: 'newName',
+              id: '1',
+              smbConferenceId: 'smbineid'
+            }
+          ]
+        });
+      }
+    });
   });
 });

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -86,6 +86,19 @@ export class ProductionManager extends EventEmitter {
     return dbManager.updateProduction(production);
   }
 
+  async updateProductionLine(
+    production: Production,
+    lineId: string,
+    lineName: string
+  ): Promise<Production | undefined> {
+    const line = production.lines.find((line) => line.id === lineId);
+    if (line) {
+      line.name = lineName;
+      return dbManager.updateProduction(production);
+    }
+    return undefined;
+  }
+
   async deleteProductionLine(
     production: Production,
     lineId: string


### PR DESCRIPTION
This PR will add a new endpoint to update the name of a line in a production.

```
PATCH /production/{productionId}/line/{lineId}
```

with the body:

```json
{
  "name": "newlinename"
}
```

It returns
```json
{
  "id": "<lineId>",
  "name": "newlinename"
}
```

More details in Swagger documentation is available