### PR TITLE
fix: guard against empty array when setting new line id

### DIFF
--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -76,8 +76,10 @@ export class ProductionManager extends EventEmitter {
     production: Production,
     newLineName: string
   ): Promise<Production | undefined> {
-    const nextLineId =
-      Math.max(...production.lines.map((line) => parseInt(line.id, 10))) + 1;
+    const nextLineId = production.lines.length
+      ? Math.max(...production.lines.map((line) => parseInt(line.id, 10))) + 1
+      : 1;
+
     production.lines.push({
       name: newLineName,
       id: nextLineId.toString(),


### PR DESCRIPTION
![image](https://github.com/Eyevinn/intercom-manager/assets/901824/0eaef09a-a0be-424a-b48e-64f5ab5acc84)

I have not tested the code since I don't have everything set up to run manager locally right now