### PR TITLE
feat: endpoint for paginated list of productions

### DIFF
--- a/src/db_manager.ts
+++ b/src/db_manager.ts
@@ -30,15 +30,20 @@ const dbManager = {
   },
 
   /** Get all productions from the database in reverse natural order, limited by the limit parameter */
-  async getProductions(limit: number): Promise<Production[]> {
+  async getProductions(limit: number, offset: number): Promise<Production[]> {
     const productions = await db
       .collection('productions')
       .find()
       .sort({ $natural: -1 })
+      .skip(offset)
       .limit(limit)
       .toArray();
 
     return productions as any as Production[];
+  },
+
+  async getProductionsLength(): Promise<number> {
+    return await db.collection('productions').countDocuments();
   },
 
   async getProduction(id: number): Promise<Production | undefined> {

--- a/src/models.ts
+++ b/src/models.ts
@@ -4,6 +4,7 @@ export type NewProduction = Static<typeof NewProduction>;
 export type NewProductionLine = Static<typeof NewProductionLine>;
 export type Production = Static<typeof Production>;
 export type ProductionResponse = Static<typeof ProductionResponse>;
+export type ProductionListResponse = Static<typeof ProductionListResponse>;
 export type DetailedProductionResponse = Static<
   typeof DetailedProductionResponse
 >;
@@ -194,6 +195,13 @@ export const Production = Type.Object({
 export const ProductionResponse = Type.Object({
   name: Type.String(),
   productionId: Type.String()
+});
+
+export const ProductionListResponse = Type.Object({
+  productions: Type.Array(ProductionResponse),
+  offset: Type.Number(),
+  limit: Type.Number(),
+  totalItems: Type.Number()
 });
 
 export const DetailedProductionResponse = Type.Object({

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -112,8 +112,12 @@ export class ProductionManager extends EventEmitter {
     return undefined;
   }
 
-  async getProductions(limit = 0): Promise<Production[]> {
-    return dbManager.getProductions(limit);
+  async getProductions(limit = 0, offset = 0): Promise<Production[]> {
+    return dbManager.getProductions(limit, offset);
+  }
+
+  async getNumberOfProductions(): Promise<number> {
+    return dbManager.getProductionsLength();
   }
 
   async getProduction(id: number): Promise<Production | undefined> {


### PR DESCRIPTION
This PR adds an endpoint that provides a paginated list of all productions: `/productionlist`
Marks the current endpoint `/production` as deprecated but still available