### PR TITLE
feat: endpoint to generate a share url that supports OSC delegate tokens

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Intercom solution powered by Symphony Media Bridge. This is the Intercom manager
 | `SMB_ADDRESS`               | The address:port of the Symphony Media Bridge instance                       |
 | `SMB_APIKEY`                | When set, provide this API key for the Symphony Media Bridge (optional)      |
 | `DB_CONNECTION_STRING`      | DB connection string (default: `mongodb://localhost:27017/intercom-manager`) |
+| `PUBLIC_HOST`               | Hostname for frontend application for generating URLs to share               |
 | `MONGODB_CONNECTION_STRING` | DEPRECATED: MongoDB connection string                                        |
 
 ## Installation / Usage

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,13 +1,15 @@
 import api from './api';
 
 jest.mock('./db/interface');
+jest.mock('./db/mongodb');
 
 describe('api', () => {
   it('responds with hello, world!', async () => {
     const server = await api({
       title: 'my awesome service',
       smbServerBaseUrl: 'http://localhost',
-      endpointIdleTimeout: '60'
+      endpointIdleTimeout: '60',
+      publicHost: 'http://localhost'
     });
     const response = await server.inject({
       method: 'GET',

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,7 @@ import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 import { Static, Type } from '@sinclair/typebox';
 import { FastifyPluginCallback } from 'fastify';
 import { getApiProductions } from './api_productions';
+import apiShare from './api_share';
 
 const HelloWorld = Type.String({
   description: 'The magical words!'
@@ -42,6 +43,7 @@ export interface ApiOptions {
   smbServerBaseUrl: string;
   endpointIdleTimeout: string;
   smbServerApiKey?: string;
+  publicHost: string;
 }
 
 export default async (opts: ApiOptions) => {
@@ -74,6 +76,7 @@ export default async (opts: ApiOptions) => {
     endpointIdleTimeout: opts.endpointIdleTimeout,
     smbServerApiKey: opts.smbServerApiKey
   });
+  api.register(apiShare, { publicHost: opts.publicHost, prefix: 'api/v1' });
 
   return api;
 };

--- a/src/api_share.test.ts
+++ b/src/api_share.test.ts
@@ -1,0 +1,25 @@
+import api from './api';
+
+jest.mock('./db/mongodb');
+
+describe('share api', () => {
+  test('can generate a share link for a given application path', async () => {
+    const server = await api({
+      title: 'my awesome service',
+      smbServerBaseUrl: 'http://localhost',
+      endpointIdleTimeout: '60',
+      publicHost: 'https://example.com'
+    });
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/share',
+      body: {
+        path: '/mypath/to/share'
+      }
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      url: 'https://example.com/mypath/to/share'
+    });
+  });
+});

--- a/src/api_share.ts
+++ b/src/api_share.ts
@@ -1,0 +1,58 @@
+import { FastifyPluginCallback } from 'fastify';
+import { ErrorResponse, ShareRequest, ShareResponse } from './models';
+
+export interface ApiShareOptions {
+  publicHost: string;
+}
+
+const OSC_ENVIRONMENT = process.env.OSC_ENVIRONMENT ?? 'prod';
+
+const apiShare: FastifyPluginCallback<ApiShareOptions> = (
+  fastify,
+  opts,
+  next
+) => {
+  fastify.post<{
+    Body: ShareRequest;
+  }>(
+    '/share',
+    {
+      schema: {
+        description: 'Generate a share link for a given application path',
+        body: ShareRequest,
+        response: {
+          200: ShareResponse,
+          400: ErrorResponse
+        }
+      }
+    },
+    async (req, reply) => {
+      let shareLinkUrl = new URL(req.body.path, opts.publicHost);
+      if (process.env.OSC_ACCESS_TOKEN) {
+        const response = await fetch(
+          `https://token.svc.${OSC_ENVIRONMENT}.osaas.io/delegate/eyevinn-intercom-manager`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-pat-jwt': `Bearer ${process.env.OSC_ACCESS_TOKEN}`
+            },
+            body: JSON.stringify({
+              redirectUrl: shareLinkUrl.toString()
+            })
+          }
+        );
+        if (response.ok) {
+          const json = await response.json();
+          if (json.shareUrl) {
+            shareLinkUrl = json.shareUrl;
+          }
+        }
+      }
+      reply.send({ url: shareLinkUrl.toString() });
+    }
+  );
+  next();
+};
+
+export default apiShare;

--- a/src/models.ts
+++ b/src/models.ts
@@ -234,3 +234,13 @@ export const ErrorResponse = Type.Object({
   message: Type.String(),
   stackTrace: Type.Optional(Type.String())
 });
+
+export const ShareRequest = Type.Object({
+  path: Type.String({ description: 'The application path to share' })
+});
+export type ShareRequest = Static<typeof ShareRequest>;
+
+export const ShareResponse = Type.Object({
+  url: Type.String({ description: 'The share URL' })
+});
+export type ShareResponse = Static<typeof ShareResponse>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { checkUserStatus } from './api_productions';
 import { Log } from './log';
 
 const SMB_ADDRESS: string = process.env.SMB_ADDRESS ?? 'http://localhost:8080';
+const PUBLIC_HOST: string = process.env.PUBLIC_HOST ?? 'http://localhost:3000';
 
 if (!process.env.SMB_ADDRESS) {
   console.warn('SMB_ADDRESS environment variable not set, using defaults');
@@ -20,7 +21,8 @@ const PORT = process.env.PORT ? Number(process.env.PORT) : 8000;
     title: 'intercom-manager',
     smbServerBaseUrl: SMB_ADDRESS,
     endpointIdleTimeout: ENDPOINT_IDLE_TIMEOUT_S,
-    smbServerApiKey: process.env.SMB_APIKEY
+    smbServerApiKey: process.env.SMB_APIKEY,
+    publicHost: PUBLIC_HOST
   });
 
   server.listen({ port: PORT, host: '0.0.0.0' }, (err, address) => {


### PR DESCRIPTION
This PR adds an endpoint that the frontend can use to generate a share URL. It supports generating an OSC delegate token that is required when the intercom manager/frontend is hosted in OSC.