### PR TITLE
feat: add support for setting PUBLIC_HOST and environment from OSC_HOSTNAME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM ${NODE_IMAGE}
 ENV NODE_ENV=production
 EXPOSE 8000
 RUN mkdir /app
+COPY ./docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 RUN chown node:node /app
 USER node
 WORKDIR /app
@@ -12,4 +14,5 @@ COPY --chown=node:node ["src", "./src"]
 # Delete prepare script to avoid errors from husky
 RUN npm pkg delete scripts.prepare \
     && npm ci --omit=dev
+ENTRYPOINT [ "/app/docker-entrypoint.sh" ]
 CMD [ "npm", "run", "start" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ ! -z "$OSC_HOSTNAME" ]; then
+  export PUBLIC_HOST="https://$OSC_HOSTNAME"
+  echo "Setting PUBLIC_HOST to $PUBLIC_HOST"
+  if [ -z "$OSC_ACCESS_TOKEN" ]; then
+    echo "OSC_ACCESS_TOKEN is not set. Limited functionality will be available."
+  fi
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,16 @@
 if [ ! -z "$OSC_HOSTNAME" ]; then
   export PUBLIC_HOST="https://$OSC_HOSTNAME"
   echo "Setting PUBLIC_HOST to $PUBLIC_HOST"
+  
+  # Determine environment from hostname
+  if [[ "$OSC_HOSTNAME" == *"-dev."* ]]; then
+    export OSC_ENVIRONMENT="dev"
+  elif [[ "$OSC_HOSTNAME" == *"-stage."* ]]; then
+    export OSC_ENVIRONMENT="stage"
+  elif [[ "$OSC_HOSTNAME" == *".prod."* ]]; then
+    export OSC_ENVIRONMENT="prod"
+  fi
+  
   if [ -z "$OSC_ACCESS_TOKEN" ]; then
     echo "OSC_ACCESS_TOKEN is not set. Limited functionality will be available."
   fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,6 +16,8 @@ if [ ! -z "$OSC_HOSTNAME" ]; then
   if [ -z "$OSC_ACCESS_TOKEN" ]; then
     echo "OSC_ACCESS_TOKEN is not set. Limited functionality will be available."
   fi
+
+  echo "Setting OSC_ENVIRONMENT to $OSC_ENVIRONMENT"
 fi
 
 exec "$@"


### PR DESCRIPTION
When manager is deployed in [OSC](https://www.osaas.io) we can determine the `PUBLIC_HOST` environment variable from the `OSC_HOSTNAME` variable. This is needed for the share-url functionality