### PR TITLE
fix: added early return on all ingest-endpoints

### DIFF
--- a/src/api_ingests.ts
+++ b/src/api_ingests.ts
@@ -26,6 +26,11 @@ const apiIngests: FastifyPluginCallback<ApiIngestsOptions> = (
 ) => {
   const ingestManager = opts.ingestManager;
 
+  // Hook to return 405 for all ingest routes
+  fastify.addHook('preHandler', async (request, reply) => {
+    reply.code(405).send({ message: 'Method Not Allowed' });
+  });
+
   fastify.post<{
     Body: NewIngest;
     Reply: { success: boolean; message: string };


### PR DESCRIPTION
Now all ingest-endpoints return a `405 Method Not Allowed` because the ingests are not fully implemented.