### PR TITLE
Fix add all statuscodes to schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.0.1",
-    "@fastify/rate-limit": "^10.3.0",
     "@fastify/swagger": "^9.5.1",
     "@fastify/swagger-ui": "^5.2.2",
     "@fastify/type-provider-typebox": "^5.1.0",
@@ -36,6 +35,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.8.1",
     "@commitlint/config-conventional": "^17.8.1",
+    "@fastify/rate-limit": "^10.3.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^18.19.100",
     "@types/sdp-transform": "^2.4.9",

--- a/src/api_whip.test.ts
+++ b/src/api_whip.test.ts
@@ -80,6 +80,10 @@ const createTestServer = async () => {
     }
   );
 
+  fastify.register(require('@fastify/rate-limit'), {
+    global: false
+  });
+
   fastify.register(apiWhip, defaultOptions);
   await fastify.ready();
   return fastify;
@@ -151,6 +155,39 @@ describe('apiWhip', () => {
       });
 
       expect(response.statusCode).toBe(415);
+    });
+
+    it('should return 429 when rate limit is exceeded', async () => {
+      const fastify = await createTestServer();
+
+      // Send 10 valid requests (these should succeed or at least not trigger 429)
+      for (let i = 0; i < 10; i++) {
+        await fastify.inject({
+          method: 'POST',
+          url: '/whip/prod1/line1/testuser',
+          headers: {
+            'content-type': 'application/sdp'
+          },
+          payload: 'v=0\r\n' // minimal SDP body
+        });
+      }
+
+      // The 11th request should exceed the rate limit
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/whip/prod1/line1/testuser',
+        headers: {
+          'content-type': 'application/sdp'
+        },
+        payload: 'v=0\r\n'
+      });
+
+      expect(response.statusCode).toBe(429);
+      expect(JSON.parse(response.body)).toEqual(
+        expect.objectContaining({
+          error: expect.stringMatching(/Too many/i)
+        })
+      );
     });
   });
 

--- a/src/api_whip.test.ts
+++ b/src/api_whip.test.ts
@@ -1,3 +1,4 @@
+import rateLimit from '@fastify/rate-limit';
 import Fastify from 'fastify';
 import { CoreFunctions } from './api_productions_core_functions';
 import apiWhip from './api_whip';
@@ -80,7 +81,7 @@ const createTestServer = async () => {
     }
   );
 
-  fastify.register(require('@fastify/rate-limit'), {
+  fastify.register(rateLimit, {
     global: false
   });
 

--- a/src/api_whip.ts
+++ b/src/api_whip.ts
@@ -63,6 +63,9 @@ export const apiWhip: FastifyPluginCallback<ApiWhipOptions> = (
         response: {
           201: WhipResponse,
           400: Type.Object({ error: Type.String() }),
+          406: Type.Object({ error: Type.String() }),
+          415: Type.Object({ error: Type.String() }),
+          429: Type.Object({ error: Type.String() }),
           500: Type.Object({ error: Type.String() })
         }
       },
@@ -70,10 +73,15 @@ export const apiWhip: FastifyPluginCallback<ApiWhipOptions> = (
         rateLimit: {
           max: 10,
           timeWindow: '1 minute',
-          errorResponseBuilder: () => ({
-            error: 'Too many requests, please try again later',
-            code: 429
-          })
+          hook: 'onRequest',
+          errorResponseBuilder: (_req, context) => {
+            return {
+              statusCode: 429,
+              error: 'Too Many Requests',
+              message: 'Too many requests, please try again later',
+              expiresIn: context.after
+            };
+          }
         }
       }
     },


### PR DESCRIPTION
The POST request to the whip endpoint returned 3 status codes that were not stated in the endpoint's schema, which this PR fixes. There was also no test for the return of the rateLimit 429 error, so a test for that has been added as well.