### PR TITLE
fix: fixed unittest failure in api_productions.test

### DIFF
--- a/src/api_productions.test.ts
+++ b/src/api_productions.test.ts
@@ -2,7 +2,7 @@ import api from './api';
 import { NewProduction, Production } from './models';
 
 
-// Mocking production objects
+// mocking production objects
 const newProduction: NewProduction = {
   name: 'productionname',
   lines: [
@@ -82,7 +82,7 @@ const mockUserSession = {
   isWhip: false
 };
 
-// Setting up manager mocks
+// setting up manager mocks
 const mockProductions = [
   {
     _id: 1,
@@ -123,29 +123,24 @@ const mockProductionManager = {
     const found = mockProductions.find((p) => p._id === id);
     return found || { _id: id, name: `prod-${id}`, lines: [] };
   }),
-  updateProduction: jest
-    .fn()
+  updateProduction: jest.fn()
     .mockImplementation(async (production: any, newName: string) => ({
       _id: production._id,
       name: newName
     })),
   addProductionLine: jest.fn().mockResolvedValue(undefined),
-  updateProductionLine: jest
-    .fn()
+  updateProductionLine: jest.fn()
     .mockImplementation(
       async (_production: any, _lineId: string, _newName: string) => ({})
     ),
   getUsersForLine: jest.fn().mockImplementation(() => []),
   userSessions: { 'mock-session': mockUserSession },
-  getProductions: jest
-    .fn()
+  getProductions: jest.fn()
     .mockImplementation(async (limit: number, offset: number) =>
       mockProductions.slice(offset, offset + limit)
     ),
   getNumberOfProductions: jest.fn().mockResolvedValue(3),
-  getLine: jest
-    .fn()
-    .mockImplementation((lines: any[], id: string) =>
+  getLine: jest.fn().mockImplementation((lines: any[], id: string) =>
       lines.find((l) => l.id === id)
     ),
   updateUserLastSeen: jest.fn()
@@ -154,7 +149,7 @@ const mockProductionManager = {
   deleteProduction: jest.fn().mockResolvedValue(true),
   removeUserSession: jest.fn()
     .mockImplementation((sessionId: string) => sessionId), 
-  checkUserStatus: jest.fn(async () => undefined)
+  checkUserStatus: jest.fn()
 } as any;
 
 describe('Production API', () => {
@@ -162,8 +157,8 @@ describe('Production API', () => {
   let setIntervalSpy: jest.SpyInstance<any, any>;
   let consoleErrorSpy: jest.SpyInstance<any, any>; // to remove negative test errors from console (console.error)
 
-  // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close properly
   beforeAll(() => {
+      // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close properly
     setIntervalSpy = jest.spyOn(global, 'setInterval')
       .mockImplementation((..._args: any[]) => 1 as unknown as NodeJS.Timeout);
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/src/api_productions.test.ts
+++ b/src/api_productions.test.ts
@@ -1,7 +1,6 @@
 import api from './api';
 import { NewProduction, Production } from './models';
 
-
 // Mocking production objects
 const newProduction: NewProduction = {
   name: 'productionname',
@@ -123,32 +122,39 @@ const mockProductionManager = {
     const found = mockProductions.find((p) => p._id === id);
     return found || { _id: id, name: `prod-${id}`, lines: [] };
   }),
-  updateProduction: jest.fn()
+  updateProduction: jest
+    .fn()
     .mockImplementation(async (production: any, newName: string) => ({
       _id: production._id,
       name: newName
     })),
   addProductionLine: jest.fn().mockResolvedValue(undefined),
-  updateProductionLine: jest.fn()
+  updateProductionLine: jest
+    .fn()
     .mockImplementation(
       async (_production: any, _lineId: string, _newName: string) => ({})
     ),
   getUsersForLine: jest.fn().mockImplementation(() => []),
   userSessions: { 'mock-session': mockUserSession },
-  getProductions: jest.fn()
+  getProductions: jest
+    .fn()
     .mockImplementation(async (limit: number, offset: number) =>
       mockProductions.slice(offset, offset + limit)
     ),
   getNumberOfProductions: jest.fn().mockResolvedValue(3),
-  getLine: jest.fn().mockImplementation((lines: any[], id: string) =>
+  getLine: jest
+    .fn()
+    .mockImplementation((lines: any[], id: string) =>
       lines.find((l) => l.id === id)
     ),
-  updateUserLastSeen: jest.fn()
+  updateUserLastSeen: jest
+    .fn()
     .mockImplementation((sessionId: string) => sessionId === 'alive-session'),
   deleteProductionLine: jest.fn().mockResolvedValue(undefined),
   deleteProduction: jest.fn().mockResolvedValue(true),
-  removeUserSession: jest.fn()
-    .mockImplementation((sessionId: string) => sessionId), 
+  removeUserSession: jest
+    .fn()
+    .mockImplementation((sessionId: string) => sessionId),
   checkUserStatus: jest.fn()
 } as any;
 
@@ -159,9 +165,12 @@ describe('Production API', () => {
 
   // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close properly
   beforeAll(() => {
-    setIntervalSpy = jest.spyOn(global, 'setInterval')
+    setIntervalSpy = jest
+      .spyOn(global, 'setInterval')
       .mockImplementation(jest.fn());
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
   });
 
   beforeAll(async () => {

--- a/src/api_productions.test.ts
+++ b/src/api_productions.test.ts
@@ -1,6 +1,7 @@
 import api from './api';
 import { NewProduction, Production } from './models';
 
+
 // Mocking production objects
 const newProduction: NewProduction = {
   name: 'productionname',
@@ -147,18 +148,25 @@ const mockProductionManager = {
     .mockImplementation((lines: any[], id: string) =>
       lines.find((l) => l.id === id)
     ),
-  updateUserLastSeen: jest
-    .fn()
+  updateUserLastSeen: jest.fn()
     .mockImplementation((sessionId: string) => sessionId === 'alive-session'),
   deleteProductionLine: jest.fn().mockResolvedValue(undefined),
   deleteProduction: jest.fn().mockResolvedValue(true),
-  removeUserSession: jest
-    .fn()
-    .mockImplementation((sessionId: string) => sessionId)
+  removeUserSession: jest.fn()
+    .mockImplementation((sessionId: string) => sessionId), 
+  checkUserStatus: jest.fn(async () => undefined)
 } as any;
 
 describe('Production API', () => {
   let server: any;
+  let setIntervalSpy: jest.SpyInstance<any, any>;
+  let clearIntervalSpy: jest.SpyInstance<any, any>;
+
+  // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close propely
+  beforeAll(() => {
+    setIntervalSpy = jest.spyOn(global, 'setInterval')
+      .mockImplementation((..._args: any[]) => 1 as unknown as NodeJS.Timeout);
+  });
 
   beforeAll(async () => {
     server = await api({
@@ -173,8 +181,10 @@ describe('Production API', () => {
     });
   });
 
+  // mock server teardown
   afterAll(async () => {
     await server.close();
+    setIntervalSpy.mockRestore();
   });
 
   describe('POST /production', () => {

--- a/src/api_productions.test.ts
+++ b/src/api_productions.test.ts
@@ -160,12 +160,13 @@ const mockProductionManager = {
 describe('Production API', () => {
   let server: any;
   let setIntervalSpy: jest.SpyInstance<any, any>;
-  let clearIntervalSpy: jest.SpyInstance<any, any>;
+  let consoleErrorSpy: jest.SpyInstance<any, any>; // to remove negative test errors from console (console.error)
 
-  // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close propely
+  // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close properly
   beforeAll(() => {
     setIntervalSpy = jest.spyOn(global, 'setInterval')
       .mockImplementation((..._args: any[]) => 1 as unknown as NodeJS.Timeout);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   beforeAll(async () => {
@@ -185,6 +186,7 @@ describe('Production API', () => {
   afterAll(async () => {
     await server.close();
     setIntervalSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 
   describe('POST /production', () => {

--- a/src/api_productions.test.ts
+++ b/src/api_productions.test.ts
@@ -1,7 +1,8 @@
 import api from './api';
 import { NewProduction, Production } from './models';
 
-// mocking production objects
+
+// Mocking production objects
 const newProduction: NewProduction = {
   name: 'productionname',
   lines: [
@@ -81,7 +82,7 @@ const mockUserSession = {
   isWhip: false
 };
 
-// setting up manager mocks
+// Setting up manager mocks
 const mockProductions = [
   {
     _id: 1,
@@ -122,39 +123,32 @@ const mockProductionManager = {
     const found = mockProductions.find((p) => p._id === id);
     return found || { _id: id, name: `prod-${id}`, lines: [] };
   }),
-  updateProduction: jest
-    .fn()
+  updateProduction: jest.fn()
     .mockImplementation(async (production: any, newName: string) => ({
       _id: production._id,
       name: newName
     })),
   addProductionLine: jest.fn().mockResolvedValue(undefined),
-  updateProductionLine: jest
-    .fn()
+  updateProductionLine: jest.fn()
     .mockImplementation(
       async (_production: any, _lineId: string, _newName: string) => ({})
     ),
   getUsersForLine: jest.fn().mockImplementation(() => []),
   userSessions: { 'mock-session': mockUserSession },
-  getProductions: jest
-    .fn()
+  getProductions: jest.fn()
     .mockImplementation(async (limit: number, offset: number) =>
       mockProductions.slice(offset, offset + limit)
     ),
   getNumberOfProductions: jest.fn().mockResolvedValue(3),
-  getLine: jest
-    .fn()
-    .mockImplementation((lines: any[], id: string) =>
+  getLine: jest.fn().mockImplementation((lines: any[], id: string) =>
       lines.find((l) => l.id === id)
     ),
-  updateUserLastSeen: jest
-    .fn()
+  updateUserLastSeen: jest.fn()
     .mockImplementation((sessionId: string) => sessionId === 'alive-session'),
   deleteProductionLine: jest.fn().mockResolvedValue(undefined),
   deleteProduction: jest.fn().mockResolvedValue(true),
-  removeUserSession: jest
-    .fn()
-    .mockImplementation((sessionId: string) => sessionId),
+  removeUserSession: jest.fn()
+    .mockImplementation((sessionId: string) => sessionId), 
   checkUserStatus: jest.fn()
 } as any;
 
@@ -163,14 +157,11 @@ describe('Production API', () => {
   let setIntervalSpy: jest.SpyInstance<any, any>;
   let consoleErrorSpy: jest.SpyInstance<any, any>; // to remove negative test errors from console (console.error)
 
+  // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close properly
   beforeAll(() => {
-    // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close properly
-    setIntervalSpy = jest
-      .spyOn(global, 'setInterval')
-      .mockImplementation((..._args: any[]) => 1 as unknown as NodeJS.Timeout);
-    consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation((..._args: any[]) => undefined);
+    setIntervalSpy = jest.spyOn(global, 'setInterval')
+      .mockImplementation(jest.fn());
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   beforeAll(async () => {

--- a/src/api_productions.test.ts
+++ b/src/api_productions.test.ts
@@ -1,7 +1,6 @@
 import api from './api';
 import { NewProduction, Production } from './models';
 
-
 // mocking production objects
 const newProduction: NewProduction = {
   name: 'productionname',
@@ -123,32 +122,39 @@ const mockProductionManager = {
     const found = mockProductions.find((p) => p._id === id);
     return found || { _id: id, name: `prod-${id}`, lines: [] };
   }),
-  updateProduction: jest.fn()
+  updateProduction: jest
+    .fn()
     .mockImplementation(async (production: any, newName: string) => ({
       _id: production._id,
       name: newName
     })),
   addProductionLine: jest.fn().mockResolvedValue(undefined),
-  updateProductionLine: jest.fn()
+  updateProductionLine: jest
+    .fn()
     .mockImplementation(
       async (_production: any, _lineId: string, _newName: string) => ({})
     ),
   getUsersForLine: jest.fn().mockImplementation(() => []),
   userSessions: { 'mock-session': mockUserSession },
-  getProductions: jest.fn()
+  getProductions: jest
+    .fn()
     .mockImplementation(async (limit: number, offset: number) =>
       mockProductions.slice(offset, offset + limit)
     ),
   getNumberOfProductions: jest.fn().mockResolvedValue(3),
-  getLine: jest.fn().mockImplementation((lines: any[], id: string) =>
+  getLine: jest
+    .fn()
+    .mockImplementation((lines: any[], id: string) =>
       lines.find((l) => l.id === id)
     ),
-  updateUserLastSeen: jest.fn()
+  updateUserLastSeen: jest
+    .fn()
     .mockImplementation((sessionId: string) => sessionId === 'alive-session'),
   deleteProductionLine: jest.fn().mockResolvedValue(undefined),
   deleteProduction: jest.fn().mockResolvedValue(true),
-  removeUserSession: jest.fn()
-    .mockImplementation((sessionId: string) => sessionId), 
+  removeUserSession: jest
+    .fn()
+    .mockImplementation((sessionId: string) => sessionId),
   checkUserStatus: jest.fn()
 } as any;
 
@@ -158,10 +164,13 @@ describe('Production API', () => {
   let consoleErrorSpy: jest.SpyInstance<any, any>; // to remove negative test errors from console (console.error)
 
   beforeAll(() => {
-      // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close properly
-    setIntervalSpy = jest.spyOn(global, 'setInterval')
+    // uses jest spy to keep track of 'setInterval' in api_productions, otherwise won't close properly
+    setIntervalSpy = jest
+      .spyOn(global, 'setInterval')
       .mockImplementation((..._args: any[]) => 1 as unknown as NodeJS.Timeout);
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation((..._args: any[]) => undefined);
   });
 
   beforeAll(async () => {


### PR DESCRIPTION
Test failure caused by "checkUserStatus" function in api_productions not being mocked correctly in test file. 

* Added mocked value to mockProductionManager of "checkUserStatus". 
* Adding this method to be empty jest function (jest.fn()) caused the test file to not finish because of "setInterval" timer in api_productions that did not close. 
* Resolved issue of non-closing test run by adding a jest spy to replace function calls of "setInterval". 
* Added spy to clean up negative test console errors (test for console.error won't show in console when running tests). 

All tests should pass and cause no failures. 