### PR TITLE
fix: refined dbmanager interface to align with newest mongodb implementation

### DIFF
--- a/src/db/couchdb.ts
+++ b/src/db/couchdb.ts
@@ -344,15 +344,17 @@ export class DbManagerCouchDb implements DbManager {
       throw new Error('Database not connected');
     }
     const sessionDocId = `session_${sessionId}`;
-    
+
     // wrap inside try-block to be consistent with mongodb implementation
     try {
       const session = await this.nanoDb.get(sessionDocId);
       return session as any as UserSession;
     } catch (err: any) {
-      if (err.statusCode === 404) { 
-        return null; 
-      } else { throw err }
+      if (err.statusCode === 404) {
+        return null;
+      } else {
+        throw err;
+      }
     }
   }
 
@@ -371,17 +373,17 @@ export class DbManagerCouchDb implements DbManager {
       const updateData: any = { ...updates };
 
       // converts lastSeen to a timestamp
-      if ("lastSeen" in updates && typeof updates.lastSeen === "number") {
+      if ('lastSeen' in updates && typeof updates.lastSeen === 'number') {
         updateData.lastSeenAt = new Date(updates.lastSeen);
       }
 
       // to ensure lastSeenAt is a Date object
-      if ("lastSeenAt" in updates && typeof updates.lastSeenAt !== undefined) {
+      if ('lastSeenAt' in updates && typeof updates.lastSeenAt !== undefined) {
         const v = updates.lastSeenAt as any;
         updateData.lastSeenAt = v instanceof Date ? v : new Date(v);
       }
 
-      const updated = { ...doc, ...updates }
+      const updated = { ...doc, ...updates };
       await this.nanoDb.insert(updated);
       return true;
     } catch (error) {


### PR DESCRIPTION
Refined some details in the couchdb interface to match the implementation of the same functions in the mongodb interface. 

Fix: getSession does not throw error when receiving a 404 not found. Instead it returns null, as is the case with the mongodb interface. 
Fix: added lastSeen and lastSeenAt handling. 