### PR TITLE
fix: support multiple payload-types

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -178,22 +178,24 @@ export class Connection {
     const audio = this.endpointDescription.audio;
 
     // For some versions of interconnected components we may receive an array of payload-types
-    // instead of a single payload-type. We pick the one that's opus, if present, or the first, 
+    // instead of a single payload-type. We pick the one that's opus, if present, or the first,
     // and otherwise proceed as before:
-    
+
     let audioPayloadType = audio['payload-type'];
 
     if (!audioPayloadType?.id) {
-        const audioPayloadTypes = audio["payload-types"];
+        const audioPayloadTypes = audio['payload-types'];
         if (!Array.isArray(audioPayloadTypes) || audioPayloadTypes.length === 0) {
-            throw new Error(`endpointDescription.audio.payload-types missing/empty: ${JSON.stringify(audio)}`);
+            throw new Error(
+              `endpointDescription.audio.payload-types missing/empty: ${JSON.stringify(audio)}`
+            );
         }
 
         // Prefer opus if present, else first
         audioPayloadType =
-            audioPayloadTypes.find((pt: any) => pt?.name?.toLowerCase() === "opus") ?? audioPayloadTypes[0];
+            audioPayloadTypes.find((pt: { name?: string }) => pt?.name?.toLowerCase() === 'opus');
     }
-    
+
     for (const element of this.mediaStreams.audio.ssrcs) {
       const audioDescription = this.makeMediaDescription('audio');
       audioDescription.payloads = audioPayloadType.id.toString();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -177,15 +177,10 @@ export class Connection {
 
     const audio = this.endpointDescription.audio;
 
-    // Compatibility fix for later versions of Symphony Media Bridge --
-    // there's no longer just one payload-type, there is now an array of payload-types.
-    // We pick the one that's opus, if present, or the first, and otherwise
-    // proceed as before:
+    // For some versions of interconnected components we may receive an array of payload-types
+    // instead of a single payload-type. We pick the one that's opus, if present, or the first, 
+    // and otherwise proceed as before:
     
-    // Old code:
-    // const audioPayloadType = audio['payload-type'];
-
-    // New code:
     let audioPayloadType = audio['payload-type'];
 
     if (!audioPayloadType?.id) {
@@ -198,7 +193,6 @@ export class Connection {
         audioPayloadType =
             audioPayloadTypes.find((pt: any) => pt?.name?.toLowerCase() === "opus") ?? audioPayloadTypes[0];
     }
-    // End of new code.
     
     for (const element of this.mediaStreams.audio.ssrcs) {
       const audioDescription = this.makeMediaDescription('audio');


### PR DESCRIPTION
I was getting this error when trying to join an intercom channel:

Exception thrown when trying to create endpoint: TypeError: Cannot read properties of undefined (reading 'id')

Manager listening on http://127.0.0.1:8000
Media Bridge at http://host.docker.internal:8081 (60s idle timeout)
Created user session: "Meh": 5b5f9cb7-400a-4c75-a42e-1220251ea805
[connection b5ca8365-cb0f-4678-8575-077ceb054b8f] Create, sfuResourceId Meh
TypeError: Cannot read properties of undefined (reading 'id')
    at Connection.addIngestMids (/app/src/connection.ts:183:52)
    at Connection.createOffer (/app/src/connection.ts:70:10)
    at CoreFunctions.createConnection (/app/src/api_productions_core_functions.ts:69:50)
    at Object.<anonymous> (/app/src/api_productions.ts:706:46)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    
The problem was that payload-type is no longer a single entry, but there's now a payload-types array. To fix this, if we don't find payload-type, use the "opus" entry from payload-types if present, otherwise the first entry in payload-types, then proceed as before.