### PR TITLE
fix: 204 code now explicitly sends no body

### DIFF
--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -806,7 +806,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
           connectionEndpointDescription,
           request.body.sdpAnswer
         );
-        reply.code(204);
+        reply.code(204).send();
       } catch (err) {
         Log().error(err);
         reply


### PR DESCRIPTION
reply.code(204) can sometimes be defaulted to sending an empty string as body. 
Fixed by having .send() after, which ensures no body is sent. 

Closes #90 