### PR TITLE
chore: bump Fastify, fix OSC_ENVIRONMENT override, remove stray dotenv.config()

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,8 +5,10 @@ if [ ! -z "$OSC_HOSTNAME" ]; then
   echo "Setting PUBLIC_HOST to $PUBLIC_HOST"
 
   # Extract environment from auto.{env}.osaas.io format
-  OSC_ENVIRONMENT=$(echo "$OSC_HOSTNAME" | sed 's/.*auto\.\(.*\)\.osaas\.io/\1/')
-  export OSC_ENVIRONMENT
+  if [ -z "$OSC_ENVIRONMENT" ]; then
+    OSC_ENVIRONMENT=$(echo "$OSC_HOSTNAME" | sed 's/.*auto\.\(.*\)\.osaas\.io/\1/')
+    export OSC_ENVIRONMENT
+  fi
   
   if [ -z "$OSC_ACCESS_TOKEN" ]; then
     echo "OSC_ACCESS_TOKEN is not set. Limited functionality will be available."

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fastify/type-provider-typebox": "^5.1.0",
         "@sinclair/typebox": "^0.32.35",
         "dotenv": "^16.5.0",
-        "fastify": "^5.7.3",
+        "fastify": "^5.8.5",
         "mongodb": "^6.16.0",
         "nano": "^10.1.4",
         "nodemon": "^3.1.10",
@@ -3721,9 +3721,9 @@
       ]
     },
     "node_modules/fastify": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.7.4.tgz",
-      "integrity": "sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
       "funding": [
         {
           "type": "github",
@@ -3734,6 +3734,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -3744,7 +3745,7 @@
         "fast-json-stringify": "^6.0.0",
         "find-my-way": "^9.0.0",
         "light-my-request": "^6.0.0",
-        "pino": "^10.1.0",
+        "pino": "^9.14.0 || ^10.1.0",
         "process-warning": "^5.0.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fastify/type-provider-typebox": "^5.1.0",
     "@sinclair/typebox": "^0.32.35",
     "dotenv": "^16.5.0",
-    "fastify": "^5.7.3",
+    "fastify": "^5.8.5",
     "mongodb": "^6.16.0",
     "nano": "^10.1.4",
     "nodemon": "^3.1.10",

--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -1,5 +1,4 @@
 import { Type } from '@sinclair/typebox';
-import dotenv from 'dotenv';
 import { FastifyPluginCallback } from 'fastify';
 import { v4 as uuidv4 } from 'uuid';
 import { CoreFunctions } from './api_productions_core_functions';
@@ -26,7 +25,6 @@ import {
 } from './models';
 import { ProductionManager } from './production_manager';
 import { ISmbProtocol, SmbProtocol } from './smb';
-dotenv.config();
 
 export interface ApiProductionsOptions {
   smbServerBaseUrl: string;


### PR DESCRIPTION
## Summary
- Bump `fastify` from `^5.7.3` to `^5.8.5` to patch [GHSA-247c-9743-5963](https://github.com/advisories/GHSA-247c-9743-5963) (body validation bypass)
- `docker-entrypoint.sh`: respect a pre-set `OSC_ENVIRONMENT` value instead of always overriding it (closes #247)
- Remove stray `dotenv.config()` call from `src/api_productions.ts` — config loading is already handled in `src/config/load-env.ts` (closes #147)

Closes #147, Closes #221, Closes #247

> Note: #90 is already fixed on `main` and should be closed separately.

## Test plan
- [ ] Tests pass (`npm test`)
- [ ] TypeScript compiles (`npm run typecheck`)
- [ ] Lint clean (`npm run lint`)
- [ ] Prettier clean (`npm run pretty`)
- [ ] Verify `docker-entrypoint.sh` no longer clobbers a pre-set `OSC_ENVIRONMENT` when deploying with a custom value

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>