### PR TITLE
docs: document that auth is out of scope and /reauth renews the OSC token

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,14 @@ The `osc_eyevinn_intercom_manager` resource requires these variables:
 | `ICE_SERVERS`               | Comma-separated list of ICE servers in the format: `turn:username:password@turn.example.com,stun:stun.example.com`. If no STUN server is provided, and WHIP endpoints are used, Google's default STUN server (`stun:stun.l.google.com:19302`) will be used. |
 | `MONGODB_CONNECTION_STRING` | DEPRECATED: Use `DB_CONNECTION_STRING` instead                                                                                                                                                                                                              |
 
+## Authentication
+
+Intercom Manager does not provide an authentication layer of its own, and that is by design. How access is controlled is deployment specific in most cases, so it belongs to whatever fronts the service rather than to the service itself.
+
+When the service runs on Eyevinn Open Source Cloud it sits behind the OSC provided auth wall, which authenticates every request before it reaches the API. The `GET /api/v1/reauth` endpoint exists to renew the token that wall issued. It requires `OSC_ACCESS_TOKEN` to be set, requests a fresh OSC service access token from the OSC token service, and stores it in the `eyevinn-intercom-manager.sat` cookie so that API calls continue to work as the previous token approaches expiry. When `OSC_ACCESS_TOKEN` is not set the service is not running in an OSC context and the endpoint responds with `405`.
+
+Contributors should not add an in-process authentication layer to the API. An extra auth level conflicts with the OSC auth wall and breaks current deploys and installations. The one bearer key already in the code, `WHIP_AUTH_KEY`, guards only the WHIP and WHEP ingest endpoints and is not a general API authentication mechanism.
+
 ## Installation / Usage
 
 Start an Intercom Manager instance:

--- a/src/api.ts
+++ b/src/api.ts
@@ -154,6 +154,10 @@ export default async (opts: ApiOptions) => {
     smb: opts.smb
   });
   api.register(apiShare, { publicHost: opts.publicHost, prefix: 'api/v1' });
+  // Registered without an auth hook on purpose. intercom-manager ships no
+  // authentication layer of its own; in an OSC deployment the OSC provided auth
+  // wall sits in front of the whole API, and /reauth only renews the token that
+  // wall issued. See the block comment in ./api_re_auth.ts before adding auth.
   api.register(apiReAuth, { prefix: 'api/v1' });
   api.register(apiGroups, { prefix: 'api/v1', dbManager: opts.dbManager });
 

--- a/src/api_re_auth.ts
+++ b/src/api_re_auth.ts
@@ -9,6 +9,28 @@ const REAUTH_RETRY_DELAY_MS = 1000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * GET /api/v1/reauth
+ *
+ * Authentication is deliberately out of scope for intercom-manager. Access
+ * control is deployment specific in most cases, so it belongs to whatever
+ * fronts the service rather than to the service itself. When the service runs
+ * on Eyevinn Open Source Cloud it sits behind the OSC provided auth wall, which
+ * authenticates every request before it reaches this process.
+ *
+ * This endpoint exists solely to renew that externally issued credential. It
+ * exchanges the configured OSC Personal Access Token (`OSC_ACCESS_TOKEN`) for a
+ * fresh service access token from the OSC token service and stores it in the
+ * `eyevinn-intercom-manager.sat` cookie, which lives for two hours, so that API
+ * calls keep working as the previous token approaches expiry. With no
+ * `OSC_ACCESS_TOKEN` configured the service is not running in an OSC context
+ * and the route responds with 405.
+ *
+ * Do not add an in-process authentication layer to this route. An extra auth
+ * level conflicts with the OSC auth wall and breaks current deploys and
+ * installations. See
+ * https://github.com/Eyevinn/intercom-manager/pull/283#issuecomment-5231121365
+ */
 const apiReAuth: FastifyPluginCallback = (fastify, _, next) => {
   fastify.get(
     '/reauth',


### PR DESCRIPTION
Documents, in code and in the readme, that intercom-manager deliberately ships no authentication layer of its own, and that `GET /api/v1/reauth` exists to renew the OSC issued token when the service runs behind the OSC auth wall.

Contributors keep reaching for an app level bearer auth on this endpoint, so the design intent is now recorded where it will be read. Authoritative statement from birme: https://github.com/Eyevinn/intercom-manager/pull/283#issuecomment-5231121365

Documentation only. No behaviour change, no route, schema, or dependency touched.

## Changes

- `src/api_re_auth.ts`: block comment on the `/reauth` plugin explaining that auth is out of scope, that the OSC auth wall fronts the API in an OSC deployment, that this route only renews the externally issued token into the `eyevinn-intercom-manager.sat` cookie, and that adding an in-process auth layer conflicts with the auth wall and breaks current deploys and installations.
- `src/api.ts`: short comment at the registration site stating the missing auth hook is deliberate, pointing at the block comment.
- `readme.md`: new `## Authentication` section between the environment variable table and Installation / Usage, saying the same for users and contributors, and noting that the existing `WHIP_AUTH_KEY` covers only the WHIP and WHEP ingest endpoints and is not a general API auth mechanism.

Every claim in the new text was read out of the code first: the `api/v1` prefix, the `eyevinn-intercom-manager.sat` cookie name and its two hour `maxAge`, the `POST /servicetoken` call to the OSC token service with `x-pat-jwt`, and the `405` returned when `OSC_ACCESS_TOKEN` is unset.

## Verification

- `npx tsc --noEmit -p tsconfig.json` clean
- `npx prettier --check` clean on the three changed files
- `npx eslint src/api.ts src/api_re_auth.ts` 0 errors (one pre-existing `lastError` unused warning, untouched)

## Lessons

`@fastify/helmet` is declared in `package.json` but was missing from a stale local `node_modules`, so `tsc --noEmit` failed with a misleading TS2307 on an unrelated file; run `npm ci` before trusting a local typecheck in this repo. Also worth knowing for future work here: `WHIP_AUTH_KEY` is the only bearer key the backend checks, and it is scoped to WHIP and WHEP ingest only, so it is not precedent for adding bearer auth to other routes.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
