### PR TITLE
chore: release 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "intercom-manager",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "intercom-manager",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intercom-manager",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Intercom manager",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Bumps `package.json` and `package-lock.json` from 4.0.0 to 4.1.0 for the v4.1.0 release.

The version is deliberately kept in **lockstep with `intercom-frontend` 4.1.0**, even though the manager's own changes since v4.0.0 are non-functional:

- chore: update node version (#259)
- docs: document that auth is out of scope and /reauth renews the OSC token (#284)
- chore: remove unused AWS Terraform configuration (#285)

Once merged, `v4.1.0` will be tagged on the squash-merge commit and a GitHub release published, which triggers the Docker Hub image push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)