### PR TITLE
fix(security): declare 204 response schema on PATCH /session

### DIFF
--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -756,7 +756,7 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
           'Provide client local SDP description as request body to finalize connection protocol.',
         params: SessionIdParams,
         response: {
-          200: Type.String(),
+          204: Type.Null(),
           400: Type.String(),
           500: Type.String()
         }

--- a/src/api_validation.test.ts
+++ b/src/api_validation.test.ts
@@ -93,6 +93,11 @@ const mockProductionManager = {
     .mockImplementation((lines: any[], id: string) =>
       lines.find((l: any) => l.id === id)
     ),
+  requireLine: jest.fn().mockImplementation((lines: any[], id: string) => {
+    const found = lines.find((l: any) => l.id === id);
+    if (!found) throw new Error(`Line ${id} not found`);
+    return found;
+  }),
   updateUserLastSeen: jest.fn().mockReturnValue(true),
   deleteProductionLine: jest.fn().mockResolvedValue(undefined),
   deleteProduction: jest.fn().mockResolvedValue(true),
@@ -232,6 +237,25 @@ describe('Input Validation', () => {
       });
       // Should not be 400 — it will fail deeper (no session found), but param is valid
       expect(response.statusCode).not.toBe(400);
+    });
+
+    test('PATCH /session/:sessionId returns 204 with empty body on success', async () => {
+      mockDbManager.getSession.mockResolvedValueOnce({
+        productionId: '1',
+        lineId: 'lid-1',
+        endpointId: 'endpoint-1',
+        sessionDescription: { audio: {} }
+      });
+      mockCoreFunctions.handleAnswerRequest = jest
+        .fn()
+        .mockResolvedValue(undefined);
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/api/v1/session/valid-session-id',
+        body: { sdpAnswer: 'v=0\r\n' }
+      });
+      expect(response.statusCode).toBe(204);
+      expect(response.body).toBe('');
     });
 
     test('DELETE /session/:sessionId accepts non-empty sessionId', async () => {


### PR DESCRIPTION
## Summary
- The `PATCH /session/:sessionId` handler sends `reply.code(204).send()` on success, but the TypeBox `response` schema only declared `200: Type.String()`. Because 204 was undeclared, Fastify applied the wrong serializer and skipped response validation for the success path (a validation bypass).
- Replaced the incorrect `200: Type.String()` entry with `204: Type.Null()`, keeping the existing `400`/`500` entries. Minimal one-line schema change.
- Added a regression test asserting `PATCH /session/:sessionId` returns `204` with an empty body on success (backend tests mock `./log`).

## Test plan
- [x] Tests pass (`npm test`) — 244 passed
- [x] TypeScript compiles (`npm run typecheck`)
- [x] Lint clean (`npm run lint`) — 0 errors
- [x] PATCH /session returns 204 and is now schema-validated

Closes #289

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>