### PR TITLE
fix(security): bound NewSession.lineId and SdpAnswer length

### DIFF
--- a/src/api_validation.test.ts
+++ b/src/api_validation.test.ts
@@ -391,6 +391,19 @@ describe('Input Validation', () => {
       expect(response.statusCode).toBe(400);
     });
 
+    test('rejects lineId exceeding 200 characters', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/v1/session',
+        body: {
+          productionId: '1',
+          lineId: 'x'.repeat(201),
+          username: 'user'
+        }
+      });
+      expect(response.statusCode).toBe(400);
+    });
+
     test('rejects username exceeding 200 characters', async () => {
       const response = await server.inject({
         method: 'POST',

--- a/src/models.ts
+++ b/src/models.ts
@@ -306,7 +306,7 @@ export const DetailedProductionResponse = Type.Object({
 
 export const NewSession = Type.Object({
   productionId: Type.String({ minLength: 1, pattern: '^[0-9]+$' }),
-  lineId: Type.String({ minLength: 1 }),
+  lineId: Type.String({ minLength: 1, maxLength: 200 }),
   username: Type.String({ minLength: 1, maxLength: 200 })
 });
 
@@ -316,7 +316,7 @@ export const SessionResponse = Type.Object({
 });
 
 export const SdpAnswer = Type.Object({
-  sdpAnswer: Type.String()
+  sdpAnswer: Type.String({ maxLength: 65536 })
 });
 
 export const ErrorResponse = Type.Object({


### PR DESCRIPTION
## Summary
- Add `maxLength: 200` to `NewSession.lineId` in `src/models.ts` (previously only `minLength: 1`), matching the existing WHIP/WHEP convention where `lineId` is already bounded to 200 chars. This prevents unbounded, attacker-controlled input from being persisted to the database via `POST /session`.
- Add `maxLength: 65536` to `SdpAnswer.sdpAnswer` in `src/models.ts` to cap the size of the SDP answer accepted by `PATCH /session/:sessionId`.
- Add a focused regression test in `src/api_validation.test.ts` asserting a 201-char `lineId` is rejected with HTTP 400 by the `POST /session` schema.

## Test plan
- [x] Tests pass (`npm test` — 244 passed, 14 suites)
- [x] TypeScript compiles (`npm run typecheck` — no errors)
- [x] Lint clean (`npm run lint` — 0 errors; only pre-existing `any` warnings)
- [x] Prettier clean (`npx prettier --check` on changed files)
- [x] New test `rejects lineId exceeding 200 characters` passes; over-long `lineId` now returns 400

Closes #290

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>