### PR TITLE
fix(security): remove stackTrace field from ErrorResponse schema

### DIFF
--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -733,8 +733,8 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
             .send({ sessionId, sdp: sdpOffer });
         } else {
           reply.code(400).send({
-            message: 'Could not establish a media connection',
-            stackTrace: 'Failed to generate sdp offer for endpoint'
+            message:
+              'Could not establish a media connection: failed to generate sdp offer for endpoint'
           });
           return;
         }

--- a/src/models.ts
+++ b/src/models.ts
@@ -320,8 +320,7 @@ export const SdpAnswer = Type.Object({
 });
 
 export const ErrorResponse = Type.Object({
-  message: Type.String(),
-  stackTrace: Type.Optional(Type.String())
+  message: Type.String()
 });
 
 export const ShareRequest = Type.Object({


### PR DESCRIPTION
## Summary
- Remove the optional `stackTrace` field from the `ErrorResponse` TypeBox schema in `src/models.ts` so internal implementation details can never leak to clients.
- Update the 400 response in `src/api_productions.ts` to fold the useful detail into the existing human-readable `message` field instead of emitting `stackTrace`.
- Verified no other `stackTrace` references remain in the codebase.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` (243 tests, 14 suites passing)
- [x] `npm run lint` (0 errors)

Closes #258