### PR TITLE
fix(security): validate ingestId param on ingest routes

### DIFF
--- a/src/api_ingests.ts
+++ b/src/api_ingests.ts
@@ -135,6 +135,9 @@ const apiIngests: FastifyPluginCallback<ApiIngestsOptions> = (
     {
       schema: {
         description: 'Retrieves an ingest.',
+        params: Type.Object({
+          ingestId: Type.String({ minLength: 1, pattern: '^[0-9]+$' })
+        }),
         response: {
           200: Ingest,
           500: Type.String()
@@ -175,6 +178,9 @@ const apiIngests: FastifyPluginCallback<ApiIngestsOptions> = (
       schema: {
         description:
           'Modify an existing Ingest. By changing the label, the deviceOutput or the deviceInput, the ingest is updated and the new ingest is returned.',
+        params: Type.Object({
+          ingestId: Type.String({ minLength: 1, pattern: '^[0-9]+$' })
+        }),
         body: PatchIngest,
         response: {
           200: PatchIngestResponse,
@@ -247,6 +253,9 @@ const apiIngests: FastifyPluginCallback<ApiIngestsOptions> = (
     {
       schema: {
         description: 'Deletes a Ingest.',
+        params: Type.Object({
+          ingestId: Type.String({ minLength: 1, pattern: '^[0-9]+$' })
+        }),
         response: {
           200: Type.String(),
           500: Type.String()


### PR DESCRIPTION
## Summary
- Add a TypeBox `params` schema (`ingestId` as a non-empty numeric string, `^[0-9]+$`) to the GET, PATCH and DELETE `/api/v1/ingests/:ingestId` routes in `src/api_ingests.ts`.
- Previously `ingestId` was declared only as a TS generic with no Fastify schema, so it reached `parseInt` unvalidated. Malformed input is now rejected with 400 before any handler logic runs.
- Existing response schemas and handler logic are unchanged.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 243/243 pass (worker teardown warning is pre-existing/expected)
- [x] `npm run lint` — 0 errors (pre-existing warnings only)

Closes #257