### PR TITLE
fix(security): validate WHIP/WHEP OPTIONS path params

### DIFF
--- a/src/api_whep.ts
+++ b/src/api_whep.ts
@@ -314,6 +314,10 @@ export const apiWhep: FastifyPluginCallback<ApiWhepOptions> = (
     {
       schema: {
         description: 'CORS preflight and WHEP discovery endpoint',
+        params: Type.Object({
+          productionId: Type.String({ minLength: 1, maxLength: 200 }),
+          lineId: Type.String({ minLength: 1, maxLength: 200 })
+        }),
         response: {
           200: Type.String({ description: 'OK' })
         }

--- a/src/api_whip.ts
+++ b/src/api_whip.ts
@@ -315,6 +315,10 @@ export const apiWhip: FastifyPluginCallback<ApiWhipOptions> = (
     {
       schema: {
         description: 'CORS preflight and WHIP discovery endpoint',
+        params: Type.Object({
+          productionId: Type.String({ minLength: 1, maxLength: 200 }),
+          lineId: Type.String({ minLength: 1, maxLength: 200 })
+        }),
         response: {
           200: Type.String({ description: 'OK' })
         }


### PR DESCRIPTION
## Summary
- Add a TypeBox `params` schema to the WHIP OPTIONS handler (`/whip/:productionId/:lineId`) validating `productionId` and `lineId` (String, minLength 1, maxLength 200).
- Add the same `params` schema to the WHEP OPTIONS handler (`/whep/:productionId/:lineId`).
- Existing response schemas are preserved; no other handlers touched.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` all pass (243 tests; "worker process has failed to exit gracefully" warning is expected)

Closes #249