### PR TITLE
Warn at startup when PUBLIC_HOST/DB connection env vars are missing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,19 @@ if (!process.env.SMB_ADDRESS) {
   Log().warn('SMB_ADDRESS environment variable not set, using defaults');
 }
 
+if (!process.env.PUBLIC_HOST) {
+  Log().warn('PUBLIC_HOST is not set — falling back to localhost default');
+}
+
+if (
+  !process.env.DB_CONNECTION_STRING &&
+  !process.env.MONGODB_CONNECTION_STRING
+) {
+  Log().warn(
+    'DB_CONNECTION_STRING is not set — using localhost MongoDB default'
+  );
+}
+
 const ENDPOINT_IDLE_TIMEOUT_S: string =
   process.env.ENDPOINT_IDLE_TIMEOUT_S ?? '60';
 


### PR DESCRIPTION
## Summary
- Adds startup `Log().warn(...)` warnings when `PUBLIC_HOST` is not set (falls back to localhost default) and when neither `DB_CONNECTION_STRING` nor `MONGODB_CONNECTION_STRING` is set (uses localhost MongoDB default).
- Matches the style/placement of the existing `SMB_ADDRESS` startup check. Minimal addition only; no restructuring.

## Test plan
- `npm run typecheck` clean
- `npm test` — all 243 tests pass ("worker process has failed to exit gracefully" warning is expected/pre-existing)
- `npm run lint` clean on changed file

Closes #268