### PR TITLE
docs: add .env.example documenting backend environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,86 @@
+# intercom-manager environment variables
+#
+# Copy this file to `.env` and adjust the values for your setup.
+# Do NOT commit your real `.env` — it is gitignored. Only this example is tracked.
+# All values below are placeholders/examples, not real secrets.
+
+# =============================================================================
+# Required
+# =============================================================================
+
+# Base URL of the Symphony Media Bridge (SMB) REST API the manager connects to.
+# If unset the server falls back to http://localhost:8080 and logs a warning,
+# so set this explicitly in any real deployment.
+SMB_ADDRESS=http://localhost:8080
+
+# =============================================================================
+# Optional (defaults shown)
+# =============================================================================
+
+# Port the Fastify server listens on. Default: 8000
+PORT=8000
+
+# Public base URL used to build absolute links (e.g. WHIP endpoints).
+# Default: http://localhost:8000
+PUBLIC_HOST=http://localhost:8000
+
+# Database connection string. Both mongodb(+srv) and http(s) (CouchDB) protocols
+# are supported. DB_CONNECTION_STRING takes precedence over
+# MONGODB_CONNECTION_STRING; if neither is set the manager defaults to
+# mongodb://localhost:27017/intercom-manager
+DB_CONNECTION_STRING=mongodb://localhost:27017/intercom-manager
+# Legacy/alternate name for the database connection string (used if
+# DB_CONNECTION_STRING is not set).
+MONGODB_CONNECTION_STRING=mongodb://localhost:27017/intercom-manager
+
+# API key sent to the SMB REST API. Optional; leave empty if SMB requires no key.
+SMB_APIKEY=
+
+# Idle timeout (seconds) for SMB endpoints before they are torn down. Default: 60
+ENDPOINT_IDLE_TIMEOUT_S=60
+
+# Comma-separated list of ICE servers. STUN entries as `stun:host:port` and TURN
+# entries as `turn:username:credential@host`. A Google STUN server is always
+# included by default. Example:
+# ICE_SERVERS=stun:stun.l.google.com:19302,turn:user:pass@turn.example.com:3478
+ICE_SERVERS=
+
+# Comma-separated list of allowed CORS origins. Optional; if unset CORS is not
+# restricted to a specific origin.
+CORS_ORIGIN=http://localhost:5173
+
+# Shared auth key required to publish WHIP ingest streams. Optional; if set,
+# WHIP clients must present it.
+WHIP_AUTH_KEY=
+
+# --- WHIP ingest lifecycle tuning (all optional, milliseconds unless noted) ---
+
+# Warm-up grace period before a new WHIP endpoint is considered active.
+# Default: 15000
+WHIP_WARMUP_MS=15000
+
+# How long a WHIP endpoint may stay inactive before being expired. Default: 10000
+WHIP_INACTIVE_ALLOW_MS=10000
+
+# How long an absent WHIP endpoint is tolerated before being expired.
+# Default: 30000
+WHIP_ABSENCE_ALLOW_MS=30000
+
+# Number of retries before expiring a WHIP endpoint. Default: 3
+WHIP_EXPIRE_RETRIES=3
+
+# Consecutive missed checks before expiring a WHIP endpoint. Default: 3
+WHIP_EXPIRE_CONSECUTIVE_MISSES=3
+
+# --- Eyevinn Open Source Cloud (OSC) integration (optional) ---
+
+# OSC personal access token used for share/re-auth features. Optional.
+OSC_ACCESS_TOKEN=
+
+# OSC environment to target. Default: prod
+OSC_ENVIRONMENT=prod
+
+# --- Logging ---
+
+# Set to any truthy value to enable debug-level logging. Optional; unset = off.
+DEBUG=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .DS_Store
 .env
+!.env.example
 
 .terraform/
 *.tfstate


### PR DESCRIPTION
## Summary
- Add `.env.example` at the backend repo root documenting every environment variable the code actually reads (discovered via `grep process.env` in `src/`).
- Variables are grouped into Required (`SMB_ADDRESS`) and Optional (with defaults shown), each with a short comment and a placeholder example value — no real secrets.
- Covers DB connection (`DB_CONNECTION_STRING` / legacy `MONGODB_CONNECTION_STRING`), server (`PORT`, `PUBLIC_HOST`, `ENDPOINT_IDLE_TIMEOUT_S`), SMB (`SMB_APIKEY`), ICE/CORS, WHIP lifecycle tuning, OSC integration, and `DEBUG`.
- Add explicit `!.env.example` negation to `.gitignore` so the example stays tracked while real `.env` remains ignored.

## Test plan
- [x] `npm install && npm run lint` — 0 errors (pre-existing warnings only).
- [x] `git status` confirms `.env.example` is staged/tracked.
- [x] No source code changed; `package-lock.json` churn reverted.

Closes #275