### PR TITLE
fix: clean up long-poll listener and timer on client disconnect

### DIFF
--- a/src/api_productions.test.ts
+++ b/src/api_productions.test.ts
@@ -177,7 +177,10 @@ const mockProductionManager = {
     .fn()
     .mockImplementation((sessionId: string) => sessionId),
   createUserSession: jest.fn().mockResolvedValue(undefined),
-  getActiveUsers: jest.fn().mockResolvedValue([])
+  getActiveUsers: jest.fn().mockResolvedValue([]),
+  once: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn()
 } as any;
 
 describe('Production API', () => {
@@ -492,6 +495,7 @@ describe('Production API', () => {
             callback();
           }
         });
+      mockProductionManager.off = jest.fn();
       const response = await server.inject({
         method: 'POST',
         url: '/api/v1/production/1/line/1/participants'
@@ -499,6 +503,11 @@ describe('Production API', () => {
       expect(response.statusCode).toBe(200);
       const body = response.body ? JSON.parse(response.body) : [];
       expect(Array.isArray(body)).toBe(true);
+      // Cleanup must remove the 'users:change' listener on every exit path.
+      expect(mockProductionManager.off).toHaveBeenCalledWith(
+        'users:change',
+        expect.any(Function)
+      );
     });
     test('returns 500 when long poll fails due to internal error', async () => {
       const sessionsSpy = jest

--- a/src/api_productions.ts
+++ b/src/api_productions.ts
@@ -918,19 +918,29 @@ const apiProductions: FastifyPluginCallback<ApiProductionsOptions> = (
       try {
         const timeoutMs = 25_000;
 
-        // Wait until either users:change fires or timeout expires
+        // Wait until users:change fires, the timeout expires, or the client
+        // disconnects. Cleanup runs once in every exit path so the listener and
+        // timer are always released and resolve is never called twice.
         await new Promise<void>((resolve) => {
-          const onChange = () => {
+          let settled = false;
+
+          const cleanup = () => {
+            if (settled) {
+              return;
+            }
+            settled = true;
             clearTimeout(timer);
+            productionManager.off('users:change', onChange);
+            request.raw.off('close', cleanup);
             resolve();
           };
 
-          const timer = setTimeout(() => {
-            productionManager.off('users:change', onChange);
-            resolve();
-          }, timeoutMs);
+          const onChange = () => cleanup();
+
+          const timer = setTimeout(cleanup, timeoutMs);
 
           productionManager.once('users:change', onChange);
+          request.raw.on('close', cleanup);
         });
 
         const { productionId, lineId } = request.params;

--- a/src/production_manager.ts
+++ b/src/production_manager.ts
@@ -43,6 +43,10 @@ export class ProductionManager extends EventEmitter {
 
   constructor(dbManager: DbManager) {
     super();
+    // Long-poll endpoints register a transient 'users:change' listener per
+    // request, so concurrent pollers can exceed the default maxListeners (10)
+    // and emit spurious MaxListenersExceededWarning. Disable the limit.
+    this.setMaxListeners(0);
     this.dbManager = dbManager;
     this.userSessions = {};
   }


### PR DESCRIPTION
## Summary
- Add a `request.raw.on('close', ...)` cleanup handler to the `/production/:productionId/line/:lineId/participants` long-poll endpoint so the transient `users:change` listener and its 25s `setTimeout` are released immediately when a client disconnects mid-poll, rather than lingering until the timeout fires.
- Route all three exit paths (`users:change` fires, timeout expires, client closes) through a single `cleanup()` guarded by a `settled` boolean, guaranteeing symmetric listener/timer removal and preventing double-resolve.
- Call `productionManager.setMaxListeners(0)` in the `ProductionManager` constructor to suppress spurious `MaxListenersExceededWarning` under >10 concurrent pollers.

## Test plan
- [x] Tests pass (`npm test`) — 243/243
- [x] TypeScript compiles (`npm run typecheck`)
- [x] Lint clean (`npm run lint`) — 0 errors
- [x] Long-poll test asserts `off('users:change', ...)` is called on the change exit path

Closes #291

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>