### PR TITLE
fix(security): constrain WHIP/WHEP path params to prevent log injection

### DIFF
--- a/src/api_whep.ts
+++ b/src/api_whep.ts
@@ -92,9 +92,12 @@ export const apiWhep: FastifyPluginCallback<ApiWhepOptions> = (
       schema: {
         description: 'WHEP endpoint for Egress WebRTC streams',
         params: Type.Object({
-          productionId: Type.String({ maxLength: 200 }),
-          lineId: Type.String({ maxLength: 200 }),
-          username: Type.String({ maxLength: 200 })
+          productionId: Type.String({ minLength: 1, pattern: '^[0-9]+$' }),
+          lineId: Type.String({ minLength: 1, pattern: '^[0-9]+$' }),
+          username: Type.String({
+            maxLength: 200,
+            pattern: '^[\\w .-]{1,200}$'
+          })
         }),
         body: WhipWhepRequest,
         response: {

--- a/src/api_whip.test.ts
+++ b/src/api_whip.test.ts
@@ -145,7 +145,7 @@ describe('apiWhip', () => {
 
       const response = await fastify.inject({
         method: 'POST',
-        url: '/whip/prod1/line1/testuser',
+        url: '/whip/123/456/testuser',
         headers: {
           'content-type': 'application/sdp'
         },
@@ -156,7 +156,7 @@ describe('apiWhip', () => {
       expect(response.statusCode).toBe(201);
       expect(response.headers['content-type']).toBe('application/sdp');
       expect(response.headers['location']).toContain(
-        '/whip/prod1/line1/mock-session-id'
+        '/whip/123/456/mock-session-id'
       );
       expect(response.payload).toContain('v=0');
     });
@@ -170,7 +170,7 @@ describe('apiWhip', () => {
 
       const response = await fastify.inject({
         method: 'POST',
-        url: '/whip/prod1/line1/testuser',
+        url: '/whip/123/456/testuser',
         headers: {
           'content-type': 'application/sdp'
         },
@@ -192,7 +192,7 @@ describe('apiWhip', () => {
 
       const response = await fastify.inject({
         method: 'POST',
-        url: '/whip/prod1/line1/testuser',
+        url: '/whip/123/456/testuser',
         headers: {
           'content-type': 'application/json'
         },
@@ -202,6 +202,36 @@ describe('apiWhip', () => {
       expect(response.statusCode).toBe(415);
     });
 
+    it('should return 400 when username contains control chars (log injection)', async () => {
+      const fastify = await createTestServer();
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/whip/123/456/' + encodeURIComponent('evil\ninjected'),
+        headers: {
+          'content-type': 'application/sdp'
+        },
+        payload: 'v=0\r\n'
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 when productionId is not numeric', async () => {
+      const fastify = await createTestServer();
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/whip/abc/456/testuser',
+        headers: {
+          'content-type': 'application/sdp'
+        },
+        payload: 'v=0\r\n'
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
     it('should return 429 when rate limit is exceeded', async () => {
       const fastify = await createTestServer();
 
@@ -209,7 +239,7 @@ describe('apiWhip', () => {
       for (let i = 0; i < 10; i++) {
         await fastify.inject({
           method: 'POST',
-          url: '/whip/prod1/line1/testuser',
+          url: '/whip/123/456/testuser',
           headers: {
             'content-type': 'application/sdp'
           },
@@ -220,7 +250,7 @@ describe('apiWhip', () => {
       // The 11th request should exceed the rate limit
       const response = await fastify.inject({
         method: 'POST',
-        url: '/whip/prod1/line1/testuser',
+        url: '/whip/123/456/testuser',
         headers: {
           'content-type': 'application/sdp'
         },
@@ -241,7 +271,7 @@ describe('apiWhip', () => {
       const fastify = await createAuthServer();
       const res = await fastify.inject({
         method: 'POST',
-        url: '/whip/prod1/line1/testuser',
+        url: '/whip/123/456/testuser',
         headers: { 'content-type': 'application/sdp' },
         payload: 'v=0\r\n'
       });
@@ -253,7 +283,7 @@ describe('apiWhip', () => {
       const fastify = await createAuthServer();
       const res = await fastify.inject({
         method: 'POST',
-        url: '/whip/prod1/line1/testuser',
+        url: '/whip/123/456/testuser',
         headers: {
           'content-type': 'application/sdp',
           authorization: 'Bearer wrong'
@@ -268,7 +298,7 @@ describe('apiWhip', () => {
       const fastify = await createAuthServer();
       const res = await fastify.inject({
         method: 'POST',
-        url: '/whip/prod1/line1/testuser',
+        url: '/whip/123/456/testuser',
         headers: {
           'content-type': 'application/sdp',
           authorization: 'Bearer secret-123'
@@ -285,7 +315,7 @@ describe('apiWhip', () => {
       const fastify = await createAuthServer();
       const res = await fastify.inject({
         method: 'DELETE',
-        url: '/whip/prod1/line1/mock-session-id'
+        url: '/whip/123/456/mock-session-id'
       });
       expect(res.statusCode).toBe(401);
     });
@@ -294,7 +324,7 @@ describe('apiWhip', () => {
       const fastify = await createAuthServer();
       const res = await fastify.inject({
         method: 'DELETE',
-        url: '/whip/prod1/line1/mock-session-id',
+        url: '/whip/123/456/mock-session-id',
         headers: { authorization: 'Bearer secret-123' }
       });
       expect(res.statusCode).toBe(200);
@@ -309,7 +339,7 @@ describe('apiWhip', () => {
 
       const response = await fastify.inject({
         method: 'DELETE',
-        url: '/whip/prod1/line1/mock-session-id'
+        url: '/whip/123/456/mock-session-id'
       });
 
       expect(response.statusCode).toBe(200);
@@ -322,7 +352,7 @@ describe('apiWhip', () => {
 
       const response = await fastify.inject({
         method: 'DELETE',
-        url: '/whip/prod1/line1/nonexistent-session'
+        url: '/whip/123/456/nonexistent-session'
       });
 
       expect(response.statusCode).toBe(404);
@@ -378,7 +408,7 @@ describe('apiWhip', () => {
 
       const response = await fastify.inject({
         method: 'PATCH',
-        url: '/whip/prod1/line1/mock-session-id',
+        url: '/whip/123/456/mock-session-id',
         headers: { 'content-type': 'application/trickle-ice-sdpfrag' },
         payload: 'a=candidate:1 1 UDP 12345 192.168.1.2 54321 typ host'
       });

--- a/src/api_whip.ts
+++ b/src/api_whip.ts
@@ -92,9 +92,12 @@ export const apiWhip: FastifyPluginCallback<ApiWhipOptions> = (
       schema: {
         description: 'WHIP endpoint for ingesting WebRTC streams',
         params: Type.Object({
-          productionId: Type.String({ maxLength: 200 }),
-          lineId: Type.String({ maxLength: 200 }),
-          username: Type.String({ maxLength: 200 })
+          productionId: Type.String({ minLength: 1, pattern: '^[0-9]+$' }),
+          lineId: Type.String({ minLength: 1, pattern: '^[0-9]+$' }),
+          username: Type.String({
+            maxLength: 200,
+            pattern: '^[\\w .-]{1,200}$'
+          })
         }),
         body: WhipWhepRequest,
         response: {


### PR DESCRIPTION
## Summary
- The `username`, `lineId` and `productionId` path params on `POST /api/v1/whip/:productionId/:lineId/:username` and the WHEP equivalent were URL-decoded by Fastify and interpolated directly into log messages with no sanitization, allowing newline (`%0a`), carriage-return (`%0d`) and ANSI-escape (`%1b[...`) injection to forge or corrupt log entries.
- Added restrictive TypeBox `pattern` constraints on both routes: numeric-only `^[0-9]+$` for `productionId` and `lineId` (matching the existing convention in `api_productions.ts`, and correct since line/production ids are generated as numeric strings), and `^[\w .-]{1,200}$` for `username`.
- Used a literal space in the username pattern instead of `\s`, because `\s` also matches `\n`/`\r`/`\t` — the exact control characters this fix must reject. Requests carrying control chars now fail schema validation with a 400 before anything is logged.
- Added regression tests covering a control-char username and a non-numeric productionId.

## Test plan
- [x] Tests pass (`npm test`) — 245 passed (2 new)
- [x] TypeScript compiles (`npm run typecheck`)
- [x] Lint clean (`npm run lint`) — 0 errors
- [x] Control-char username / non-numeric ids rejected with 400 by schema

Closes #287

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>