### PR TITLE
fix(security): reject scheme-relative /share paths, enforce origin

### DIFF
--- a/src/api_share.test.ts
+++ b/src/api_share.test.ts
@@ -83,4 +83,35 @@ describe('share api', () => {
       url: 'https://example.com/mypath/to/share'
     });
   });
+
+  test.each([
+    '//evil.com/x',
+    '/\\evil.com',
+    '\\\\evil.com',
+    'https://evil.com',
+    'no-leading-slash'
+  ])('rejects scheme-relative or malformed share path %s', async (path) => {
+    const server = await api({
+      title: 'my awesome service',
+      smbServerBaseUrl: 'http://localhost',
+      endpointIdleTimeout: '60',
+      publicHost: 'https://example.com',
+      dbManager: mockDbManager,
+      productionManager: mockProductionManager,
+      ingestManager: mockIngestManager,
+      coreFunctions: new CoreFunctions(
+        mockProductionManager,
+        new ConnectionQueue()
+      )
+    });
+    const response = await server.inject({
+      method: 'POST',
+      url: '/api/v1/share',
+      body: {
+        path
+      }
+    });
+    expect(response.statusCode).toBe(400);
+    expect(response.json().url).toBeUndefined();
+  });
 });

--- a/src/api_share.ts
+++ b/src/api_share.ts
@@ -28,6 +28,11 @@ const apiShare: FastifyPluginCallback<ApiShareOptions> = (
     },
     async (req, reply) => {
       let shareLinkUrl = new URL(req.body.path, opts.publicHost);
+      if (shareLinkUrl.origin !== new URL(opts.publicHost).origin) {
+        return reply.code(400).send({
+          message: 'Invalid path: must resolve within the application host'
+        });
+      }
       if (process.env.OSC_ACCESS_TOKEN) {
         const response = await fetch(
           `https://token.svc.${OSC_ENVIRONMENT}.osaas.io/delegate/eyevinn-intercom-manager`,

--- a/src/models.ts
+++ b/src/models.ts
@@ -328,7 +328,7 @@ export const ShareRequest = Type.Object({
   path: Type.String({
     description: 'The application path to share',
     maxLength: 500,
-    pattern: '^/'
+    pattern: '^/(?![/\\\\]).*'
   })
 });
 export type ShareRequest = Static<typeof ShareRequest>;


### PR DESCRIPTION
## Summary
- `POST /api/v1/share` built a share URL from caller-supplied `path` validated only with TypeBox `pattern: '^/'`, which also matches scheme-relative (`//evil.com/x`) and backslash-prefixed (`/\evil.com`) values. `new URL(path, publicHost)` then resolves to an attacker-controlled origin, causing an open redirect in the returned `url` and — more seriously — in the `redirectUrl` embedded in a minted OSC delegate token.
- Defense in depth (both layers):
  1. Tightened `ShareRequest.path` pattern in `src/models.ts` to `^/(?![/\\]).*` so it requires a single leading `/` not followed by `/` or `\` (keeps `maxLength: 500`).
  2. In `src/api_share.ts`, after `new URL(req.body.path, opts.publicHost)`, assert the resolved `origin` equals `new URL(opts.publicHost).origin` and reply 400 otherwise, guarding even if the schema is bypassed.
- Both are needed: the schema rejects malformed input at the edge; the runtime origin check is a fail-safe that also catches any future URL-parsing edge cases before the value reaches the delegate service or the response.

## Test plan
- [x] Tests pass (`npm test`) — 14 suites, 248 tests
- [x] TypeScript compiles (`npm run typecheck`)
- [x] Lint clean (`npm run lint`) — 0 errors
- [x] `//evil.com`, `/\evil.com`, `\\evil.com`, `https://evil.com`, and no-slash paths rejected (400); valid paths like `/mypath/to/share` still return the correct same-origin URL

Closes #270

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>