### PR TITLE
chore: add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Dependabot version-update configuration.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to the backend repo (previously had none, unlike the frontend).
- Enable the `npm` ecosystem at the repo root on a **weekly** schedule with an open-PR limit of 10; ignore `semver-major` bumps so majors are handled manually.
- Also enable the `github-actions` ecosystem (weekly, limit 5) to keep workflow actions current.

## Test plan
- [ ] YAML parses (validated locally with the `yaml` parser — version 2, npm + github-actions).
- [ ] Dependabot picks up the config and begins opening update PRs after merge.

Closes #253

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>